### PR TITLE
Added Simple Injector implementation example.

### DIFF
--- a/src/MediatR.Examples.SimpleInjector/App.config
+++ b/src/MediatR.Examples.SimpleInjector/App.config
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SimpleInjector" publicKeyToken="984cb50dea722e99" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.1.0" newVersion="2.6.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/MediatR.Examples.SimpleInjector/MediatR.Examples.SimpleInjector.csproj
+++ b/src/MediatR.Examples.SimpleInjector/MediatR.Examples.SimpleInjector.csproj
@@ -1,0 +1,92 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{6F2DECD8-AC23-446E-96E4-F462EF76817A}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MediatR.Examples.SimpleInjector</RootNamespace>
+    <AssemblyName>MediatR.Examples.SimpleInjector</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="CommonServiceLocator.SimpleInjectorAdapter, Version=2.3.6.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\CommonServiceLocator.SimpleInjectorAdapter.2.3.6\lib\net40-client\CommonServiceLocator.SimpleInjectorAdapter.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    </Reference>
+    <Reference Include="SimpleInjector">
+      <HintPath>..\packages\SimpleInjector.2.6.1\lib\net45\SimpleInjector.dll</HintPath>
+    </Reference>
+    <Reference Include="SimpleInjector.Diagnostics">
+      <HintPath>..\packages\SimpleInjector.2.6.1\lib\net45\SimpleInjector.Diagnostics.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MediatR.Examples\MediatR.Examples.csproj">
+      <Project>{de7e7466-b06a-4e8a-9cfc-443464d55923}</Project>
+      <Name>MediatR.Examples</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\MediatR\MediatR.csproj">
+      <Project>{d0cdc351-9f10-4531-bdff-d9796487e9ce}</Project>
+      <Name>MediatR</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/MediatR.Examples.SimpleInjector/Program.cs
+++ b/src/MediatR.Examples.SimpleInjector/Program.cs
@@ -31,8 +31,8 @@
             container.RegisterManyForOpenGeneric(typeof(IAsyncNotificationHandler<>), container.RegisterAll, assemblies);
             container.Register(() => Console.Out);
 
-            IServiceProvider serviceLocator = new SimpleInjectorServiceLocatorAdapter(container);
-            var serviceLocatorProvider = new ServiceLocatorProvider(() => (IServiceLocator)serviceLocator);
+            var serviceLocator = new SimpleInjectorServiceLocatorAdapter(container);
+            var serviceLocatorProvider = new ServiceLocatorProvider(() => serviceLocator);
             container.Register(() => serviceLocatorProvider);
 
             container.Verify();

--- a/src/MediatR.Examples.SimpleInjector/Program.cs
+++ b/src/MediatR.Examples.SimpleInjector/Program.cs
@@ -1,0 +1,51 @@
+﻿namespace MediatR.Examples.SimpleInjector
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using CommonServiceLocator.SimpleInjectorAdapter;
+    using global::SimpleInjector;
+    using global::SimpleInjector.Extensions;
+    using Microsoft.Practices.ServiceLocation;
+
+    internal class Program
+    {
+        private static void Main(string[] args)
+        {
+            var mediator = BuildMediator();
+
+            Runner.Run(mediator, Console.Out);
+
+            Console.ReadKey();
+        }
+
+        private static IMediator BuildMediator()
+        {
+            var container = new Container();
+            var assemblies = GetAssemblies().ToArray();
+            container.Register<IMediator, Mediator>();
+            container.RegisterManyForOpenGeneric(typeof(IRequestHandler<,>), assemblies);
+            container.RegisterManyForOpenGeneric(typeof(IAsyncRequestHandler<,>), assemblies);
+            container.RegisterManyForOpenGeneric(typeof(INotificationHandler<>), container.RegisterAll, assemblies);
+            container.RegisterManyForOpenGeneric(typeof(IAsyncNotificationHandler<>), container.RegisterAll, assemblies);
+            container.Register(() => Console.Out);
+
+            IServiceProvider serviceLocator = new SimpleInjectorServiceLocatorAdapter(container);
+            var serviceLocatorProvider = new ServiceLocatorProvider(() => (IServiceLocator)serviceLocator);
+            container.Register(() => serviceLocatorProvider);
+
+            container.Verify();
+
+            var mediator = container.GetInstance<IMediator>();
+
+            return mediator;
+        }
+
+        private static IEnumerable<Assembly> GetAssemblies()
+        {
+            yield return typeof(IMediator).Assembly;
+            yield return typeof(Ping).Assembly;
+        }
+    }
+}

--- a/src/MediatR.Examples.SimpleInjector/Properties/AssemblyInfo.cs
+++ b/src/MediatR.Examples.SimpleInjector/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MediatR.Examples.SimpleInjector")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MediatR.Examples.SimpleInjector")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("2b028085-e306-427e-af29-6db7a583df2d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/MediatR.Examples.SimpleInjector/packages.config
+++ b/src/MediatR.Examples.SimpleInjector/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
+  <package id="CommonServiceLocator.SimpleInjectorAdapter" version="2.3.6" targetFramework="net45" />
+  <package id="SimpleInjector" version="2.6.1" targetFramework="net45" />
+</packages>

--- a/src/MediatR.sln
+++ b/src/MediatR.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediatR", "MediatR\MediatR.csproj", "{D0CDC351-9F10-4531-BDFF-D9796487E9CE}"
 EndProject
@@ -32,6 +32,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediatR.Examples.Windsor", "MediatR.Examples.Windsor\MediatR.Examples.Windsor.csproj", "{7B35EF61-0636-4BC5-8D14-18939AF867D4}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediatR.Examples.Unity", "MediatR.Examples.Unity\MediatR.Examples.Unity.csproj", "{EA6A7157-A8CD-4B85-947E-3F3C399B8A29}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediatR.Examples.SimpleInjector", "MediatR.Examples.SimpleInjector\MediatR.Examples.SimpleInjector.csproj", "{6F2DECD8-AC23-446E-96E4-F462EF76817A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -71,6 +73,10 @@ Global
 		{EA6A7157-A8CD-4B85-947E-3F3C399B8A29}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EA6A7157-A8CD-4B85-947E-3F3C399B8A29}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EA6A7157-A8CD-4B85-947E-3F3C399B8A29}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F2DECD8-AC23-446E-96E4-F462EF76817A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F2DECD8-AC23-446E-96E4-F462EF76817A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F2DECD8-AC23-446E-96E4-F462EF76817A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F2DECD8-AC23-446E-96E4-F462EF76817A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -82,5 +88,6 @@ Global
 		{18E4617F-7766-4102-AEB1-D8CCCC64C955} = {F0AA3786-7BBF-46D1-AE38-C1938F33EF20}
 		{7B35EF61-0636-4BC5-8D14-18939AF867D4} = {F0AA3786-7BBF-46D1-AE38-C1938F33EF20}
 		{EA6A7157-A8CD-4B85-947E-3F3C399B8A29} = {F0AA3786-7BBF-46D1-AE38-C1938F33EF20}
+		{6F2DECD8-AC23-446E-96E4-F462EF76817A} = {F0AA3786-7BBF-46D1-AE38-C1938F33EF20}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
[Simple Injector](https://simpleinjector.org/) has grown to a major Depedency Injection framework, yet an implementation example was missing.

I had to use v2.3.6 of the [CommonServiceLocator.SimpleInjectorAdapter](https://www.nuget.org/packages/CommonServiceLocator.SimpleInjectorAdapter/2.3.6) package, since the latest version depends on [Portable.CommonServiceLocator](https://www.nuget.org/packages/Portable.CommonServiceLocator/) which in turn has a hard dependency on CommonServiceLocator v1.0.0 while MediatR depends on v1.3.0.