### PR TITLE
Notifications are processed simultaneously.

### DIFF
--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -88,22 +88,20 @@
 
         public void Publish(INotification notification)
         {
-            var notificationHandlers = GetNotificationHandlers(notification);
+            var notificationHandlers = GetNotificationHandlers(notification)
+                .Select(handler => Task.Run(() => handler.Handle(notification)))
+                .ToArray();
 
-            foreach (var handler in notificationHandlers)
-            {
-                handler.Handle(notification);
-            }
+            Task.WaitAll(notificationHandlers);
         }
 
         public async Task PublishAsync(IAsyncNotification notification)
         {
-            var notificationHandlers = GetAsyncNotificationHandlers(notification);
+            var notificationHandlers = GetAsyncNotificationHandlers(notification)
+                .Select(handler => Task.Run(() => handler.Handle(notification)))
+                .ToArray();
 
-            foreach (var handler in notificationHandlers)
-            {
-                await handler.Handle(notification);
-            }
+            await Task.WhenAll(notificationHandlers);
         }
 
         private static InvalidOperationException BuildException(object message, Exception inner = null)


### PR DESCRIPTION
Since notifications may have multiple subscribers it's better to process it simultaneously because each of them may take much time.