### PR TITLE
Added a "NoContainer" example

### DIFF
--- a/src/MediatR.Examples.NoContainer/App.config
+++ b/src/MediatR.Examples.NoContainer/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" />
+    </startup>
+</configuration>

--- a/src/MediatR.Examples.NoContainer/MediatR.Examples.NoContainer.csproj
+++ b/src/MediatR.Examples.NoContainer/MediatR.Examples.NoContainer.csproj
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{616E03A2-46DC-4193-AB9A-E71E2BFC4D52}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MediatR.Examples.NoContainer</RootNamespace>
+    <AssemblyName>MediatR.Examples.NoContainer</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MediatR.Examples\MediatR.Examples.csproj">
+      <Project>{DE7E7466-B06A-4E8A-9CFC-443464D55923}</Project>
+      <Name>MediatR.Examples</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\MediatR\MediatR.csproj">
+      <Project>{D0CDC351-9F10-4531-BDFF-D9796487E9CE}</Project>
+      <Name>MediatR</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/MediatR.Examples.NoContainer/Program.cs
+++ b/src/MediatR.Examples.NoContainer/Program.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MediatR.Examples.NoContainer
+{
+    class Program
+    {
+        static void Main()
+        {
+            var mediator = BuildMediator();
+            Runner.Run(mediator, Console.Out);
+            Console.ReadKey();
+        }
+
+        private static IMediator BuildMediator()
+        {
+            var mediator = new Mediator(SingleInstanceFactory, MultiInstanceFactory);
+            return mediator;
+        }
+
+        private static IEnumerable<object> MultiInstanceFactory(Type serviceType)
+        {
+            return AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(s => s.GetTypes())
+                .Where(serviceType.IsAssignableFrom)
+                .Select(type => Activator.CreateInstance(type, Console.Out));
+        }
+
+        private static object SingleInstanceFactory(Type serviceType)
+        {
+            var type = AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(s => s.GetTypes())
+                .First(serviceType.IsAssignableFrom);
+            return Activator.CreateInstance(type);
+        }
+    }
+}

--- a/src/MediatR.Examples.NoContainer/Properties/AssemblyInfo.cs
+++ b/src/MediatR.Examples.NoContainer/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MediatR.Examples.NoContainer")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MediatR.Examples.NoContainer")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("1c29215f-9ca6-4431-8161-a8cedef0ac40")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/MediatR.sln
+++ b/src/MediatR.sln
@@ -41,6 +41,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "MediatR.CoreCLR", "MediatR\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediatR", "MediatR\MediatR.csproj", "{D0CDC351-9F10-4531-BDFF-D9796487E9CE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediatR.Examples.NoContainer", "MediatR.Examples.NoContainer\MediatR.Examples.NoContainer.csproj", "{616E03A2-46DC-4193-AB9A-E71E2BFC4D52}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -95,6 +97,10 @@ Global
 		{D0CDC351-9F10-4531-BDFF-D9796487E9CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D0CDC351-9F10-4531-BDFF-D9796487E9CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D0CDC351-9F10-4531-BDFF-D9796487E9CE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{616E03A2-46DC-4193-AB9A-E71E2BFC4D52}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{616E03A2-46DC-4193-AB9A-E71E2BFC4D52}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{616E03A2-46DC-4193-AB9A-E71E2BFC4D52}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{616E03A2-46DC-4193-AB9A-E71E2BFC4D52}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -110,5 +116,6 @@ Global
 		{363449D4-8541-4DE2-82B2-64CE7A2DDAE2} = {F0AA3786-7BBF-46D1-AE38-C1938F33EF20}
 		{13A843A3-F162-4FF0-A133-A01DD15D21BD} = {F0AA3786-7BBF-46D1-AE38-C1938F33EF20}
 		{D0CDC351-9F10-4531-BDFF-D9796487E9CE} = {F0AA3786-7BBF-46D1-AE38-C1938F33EF20}
+		{616E03A2-46DC-4193-AB9A-E71E2BFC4D52} = {F0AA3786-7BBF-46D1-AE38-C1938F33EF20}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
[Today I noticed](https://twitter.com/jbogard/status/600674030098587648) that after v1.0 (I mean, in `-pre` nuget packages) MediatR doesn't have a ServiceLocator constructor dependency and I can create a Mediator instance using two new delegates. In this new example I'm using `Activator.CreateInstance` to create the instance from the Mediator interfaces