### PR TITLE
Added cancellation tokens to all async APIs

### DIFF
--- a/src/MediatR.Examples/GenericAsyncHandler.cs
+++ b/src/MediatR.Examples/GenericAsyncHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace MediatR.Examples
@@ -12,7 +13,7 @@ namespace MediatR.Examples
             _writer = writer;
         }
 
-        public async Task Handle(IAsyncNotification notification)
+        public async Task Handle(IAsyncNotification notification, CancellationToken cancellationToken)
         {
             await _writer.WriteLineAsync("Got notified also async.");
         }

--- a/src/MediatR.Examples/PingAsyncHandler.cs
+++ b/src/MediatR.Examples/PingAsyncHandler.cs
@@ -1,10 +1,11 @@
 ﻿namespace MediatR.Examples
 {
+    using System.Threading;
     using System.Threading.Tasks;
 
     public class PingAsyncHandler : IAsyncRequestHandler<PingAsync, Pong>
     {
-        public async Task<Pong> Handle(PingAsync message)
+        public async Task<Pong> Handle(PingAsync message, CancellationToken cancellationToken)
         {
             return await Task.Factory.StartNew(() => new Pong { Message = message.Message + " Pong" });
         }

--- a/src/MediatR.Examples/PingedAsyncHandler.cs
+++ b/src/MediatR.Examples/PingedAsyncHandler.cs
@@ -1,6 +1,7 @@
 ﻿namespace MediatR.Examples
 {
     using System.IO;
+    using System.Threading;
     using System.Threading.Tasks;
 
     public class PingedAsyncHandler : IAsyncNotificationHandler<PingedAsync>
@@ -12,7 +13,7 @@
             _writer = writer;
         }
 
-        public async Task Handle(PingedAsync notification)
+        public async Task Handle(PingedAsync notification, CancellationToken cancellationToken)
         {
             await _writer.WriteLineAsync("Got pinged async.");
         }
@@ -27,7 +28,7 @@
             _writer = writer;
         }
 
-        public async Task Handle(PingedAsync notification)
+        public async Task Handle(PingedAsync notification, CancellationToken cancellationToken)
         {
             await _writer.WriteLineAsync("Got pinged also async.");
         }

--- a/src/MediatR.Tests/AsyncPublishTests.cs
+++ b/src/MediatR.Tests/AsyncPublishTests.cs
@@ -7,6 +7,7 @@
     using Shouldly;
     using StructureMap;
     using StructureMap.Graph;
+    using System.Threading;
 
     public class AsyncPublishTests
     {
@@ -24,7 +25,7 @@
                 _writer = writer;
             }
 
-            public async Task Handle(Ping message)
+            public async Task Handle(Ping message, CancellationToken cancellationToken)
             {
                 await _writer.WriteLineAsync(message.Message + " Pong");
             }

--- a/src/MediatR.Tests/AsyncSendVoidTests.cs
+++ b/src/MediatR.Tests/AsyncSendVoidTests.cs
@@ -6,6 +6,7 @@
     using Shouldly;
     using StructureMap;
     using StructureMap.Graph;
+    using System.Threading;
 
     public class AsyncSendVoidTests
     {
@@ -23,7 +24,7 @@
                 _writer = writer;
             }
 
-            protected async override Task HandleCore(Ping message)
+            protected async override Task HandleCore(Ping message, CancellationToken cancellationToken)
             {
                 await _writer.WriteAsync(message.Message + " Pong");
             }

--- a/src/MediatR/IHandler.cs
+++ b/src/MediatR/IHandler.cs
@@ -1,4 +1,6 @@
-﻿namespace MediatR
+﻿using System.Threading;
+
+namespace MediatR
 {
     using System.Threading.Tasks;
 
@@ -30,8 +32,9 @@
         /// Handles an asynchronous request
         /// </summary>
         /// <param name="message">The request message</param>
+        /// <param name="cancellationToken">A cancellation token</param>
         /// <returns>A task representing the response from the request</returns>
-        Task<TResponse> Handle(TRequest message);
+        Task<TResponse> Handle(TRequest message, CancellationToken cancellationToken);
     }
 
     /// <summary>
@@ -62,9 +65,9 @@
     public abstract class AsyncRequestHandler<TMessage> : IAsyncRequestHandler<TMessage, Unit>
         where TMessage : IAsyncRequest
     {
-        public async Task<Unit> Handle(TMessage message)
+        public async Task<Unit> Handle(TMessage message, CancellationToken cancellationToken)
         {
-            await HandleCore(message);
+            await HandleCore(message, cancellationToken);
 
             return Unit.Value;
         }
@@ -73,8 +76,9 @@
         /// Handles a void request
         /// </summary>
         /// <param name="message">The request message</param>
+        /// <param name="cancellationToken">A cancellation token</param>
         /// <returns>A task representing the void response from the request</returns>
-        protected abstract Task HandleCore(TMessage message);
+        protected abstract Task HandleCore(TMessage message, CancellationToken cancellationToken);
     }
 
     /// <summary>
@@ -102,7 +106,8 @@
         /// Handles an asynchronous notification
         /// </summary>
         /// <param name="notification">The notification message</param>
+        /// <param name="cancellationToken">A cancellation token</param>
         /// <returns>A task representing handling the notification</returns>
-        Task Handle(TNotification notification);
+        Task Handle(TNotification notification, CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
When you have async APIs it's nice to be able to cancel some work being done by handlers. Since you're breaking things (for v2) anyway, I figured I might as well pitch this PR which adds a `CancellationToken` parameter to all the async APIs.

Since optional arguments [don't version very well](http://haacked.com/archive/2010/08/10/versioning-issues-with-optional-arguments.aspx/), I figured it's best to keep the amount to a minimum. I opted for optional arguments only on the methods that are meant to be called by the consumer, i.e. `IMediator`'s methods. Shout out if you want them changed to overloads without the tokens. A third alternative is to keep methods *with* the tokens and provide extension methods passing `default(CancellationToken)` or `CancellationToken.None` instead.