### PR TITLE
Make the Mediator's handler caches static

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -47,8 +47,7 @@ function Build-TestProjects
 function Test-Projects
 {
     param([string] $DirectoryName)
-	#Waiting for Shouldly to support dnxcore
-    #& dnx -p ("""" + $DirectoryName + """") test; if($LASTEXITCODE -ne 0) { exit 2 }
+	& dnx -p ("""" + $DirectoryName + """") test; if($LASTEXITCODE -ne 0) { exit 2 }
 }
 
 function Remove-PathVariable
@@ -99,6 +98,7 @@ Get-ChildItem -Path .\test -Filter *.xproj -Recurse | ForEach-Object { Test-Proj
 dnvm use $dnxVersion -r CoreCLR
 
 # Test again
-Get-ChildItem -Path .\test -Filter *.xproj -Recurse | ForEach-Object { Test-Projects $_.DirectoryName }
+#Waiting for Shouldly to support dnxcore
+#Get-ChildItem -Path .\test -Filter *.xproj -Recurse | ForEach-Object { Test-Projects $_.DirectoryName }
 
 Pop-Location

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -18,8 +18,8 @@ namespace MediatR
 
         private readonly MultiInstanceFactory _multiInstanceFactory;
 
-        private readonly ConcurrentDictionary<Type, Type> _genericHandlerCache;
-        private readonly ConcurrentDictionary<Type, Type> _wrapperHandlerCache;
+        private static readonly ConcurrentDictionary<Type, Type> _genericHandlerCache = new ConcurrentDictionary<Type, Type>();
+        private static readonly ConcurrentDictionary<Type, Type> _wrapperHandlerCache = new ConcurrentDictionary<Type, Type>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Mediator"/> class.
@@ -30,8 +30,6 @@ namespace MediatR
         {
             _singleInstanceFactory = singleInstanceFactory;
             _multiInstanceFactory = multiInstanceFactory;
-            _genericHandlerCache = new ConcurrentDictionary<Type, Type>();
-            _wrapperHandlerCache = new ConcurrentDictionary<Type, Type>();
         }
 
         public TResponse Send<TResponse>(IRequest<TResponse> request)


### PR DESCRIPTION
This should address #71. The recommended approach would be to create a new Mediator instance per request, without incurring the cost of `MakeGenericType` every time.
