### PR TITLE
Make GetHandler and GetNotificationHandlers extensible

### DIFF
--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -122,7 +122,7 @@ namespace MediatR
             return (TWrapper) Activator.CreateInstance(genericWrapperType, handler);
         }
 
-        private object GetHandler(object request, Type handlerType)
+        protected virtual object GetHandler(object request, Type handlerType)
         {
             try
             {
@@ -168,7 +168,7 @@ namespace MediatR
                 .ToList();
         }
 
-        private IEnumerable<object> GetNotificationHandlers(object notification, Type handlerType)
+        protected virtual IEnumerable<object> GetNotificationHandlers(object notification, Type handlerType)
         {
             try
             {


### PR DESCRIPTION
Hi,

I'm proposing a simple change to make the properties GetHandler and GetNotificationHandlers extensible via inheritance. I don't think it would cause any harm and would enable better control over how the Handler can be resolved, since the Instance Factories only have knowledge of the type that has to be resolved, but knowledge of the request can be valuable in some scenarios.

Cause for this pull request is the following scenario I have: 
I'm having multiple handlers for a single request that do the same thing but use different remote services, so their implementation is entirely different. Which handler to choose is up to some highly complicated runtime DI magic. For testing purposes however I'd like to flag a specific request to make sure that one specific remote service is used, basically I want to circumvent my complicated code and take a shortcut based on a specific flag on a request object. Since this is only for some requests and will be triggered via UI and not inside Visual Studio I currently see no other way but to either re-implement to entire Mediator class or use this pull request.

I know it's kind of an esoteric use case but hope that you'll see what I want to achieve.

Cheers 
Peter
