### PR TITLE
Porting to .NET Core 1.0 RTM

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "projects": [ "src", "test", "samples" ],
   "sdk": {
-    "version": "1.0.0-preview1-002702"
+    "version": "1.0.0-preview2-003121"
   }
 }

--- a/samples/MediatR.Examples.AspNetCore/project.json
+++ b/samples/MediatR.Examples.AspNetCore/project.json
@@ -1,11 +1,11 @@
 ﻿{
   "dependencies": {
     "MediatR.Examples": { "target": "project" },
-    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-final",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0",
     "Scrutor": "1.6.0",
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002702"
+      "version": "1.0.0"
     }
   },
 

--- a/samples/MediatR.Examples.Autofac/project.json
+++ b/samples/MediatR.Examples.Autofac/project.json
@@ -1,10 +1,10 @@
 ﻿{
   "dependencies": {
-    "Autofac": "4.0.0-rc2-240",
+    "Autofac": "4.0.0-rc3-286",
     "MediatR.Examples": { "target": "project" },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002702"
+      "version": "1.0.0"
     }
   },
 

--- a/samples/MediatR.Examples.DryIoc/project.json
+++ b/samples/MediatR.Examples.DryIoc/project.json
@@ -1,10 +1,10 @@
 ﻿{
   "dependencies": {
-    "DryIoc.Dnx": "2.2.2-rc1",
+    "DryIoc":  "2.6.2",
     "MediatR.Examples": { "target": "project" },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002702"
+      "version": "1.0.0"
     }
   },
 

--- a/samples/MediatR.Examples.LightInject/project.json
+++ b/samples/MediatR.Examples.LightInject/project.json
@@ -1,10 +1,10 @@
 ﻿{
   "dependencies": {
-    "LightInject": "4.0.9",
+    "LightInject": "4.0.10",
     "MediatR.Examples": { "target": "project" },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002702"
+      "version": "1.0.0"
     }
   },
 

--- a/samples/MediatR.Examples.SimpleInjector/project.json
+++ b/samples/MediatR.Examples.SimpleInjector/project.json
@@ -1,10 +1,10 @@
 ﻿{
   "dependencies": {
-    "SimpleInjector": "3.2.0-alpha2",
+    "SimpleInjector": "3.2.0",
     "MediatR.Examples": { "target": "project" },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002702"
+      "version": "1.0.0"
     }
   },
 

--- a/samples/MediatR.Examples.StructureMap/project.json
+++ b/samples/MediatR.Examples.StructureMap/project.json
@@ -4,7 +4,7 @@
     "MediatR.Examples": { "target": "project" },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002702"
+      "version": "1.0.0"
     }
   },
 

--- a/samples/MediatR.Examples/project.json
+++ b/samples/MediatR.Examples/project.json
@@ -11,11 +11,11 @@
     },
     "netstandard1.1": {
       "dependencies": {
-        "Microsoft.CSharp": "4.0.1-rc2-24027",
-        "System.Collections": "4.0.11-rc2-24027",
-        "System.Linq": "4.1.0-rc2-24027",
-        "System.Runtime": "4.1.0-rc2-24027",
-        "System.Threading": "4.0.11-rc2-24027"
+        "Microsoft.CSharp": "4.0.1",
+        "System.Collections": "4.0.11",
+        "System.Linq": "4.1.0",
+        "System.Runtime": "4.1.0",
+        "System.Threading": "4.0.11"
       }
     }
   }

--- a/src/MediatR/project.json
+++ b/src/MediatR/project.json
@@ -19,9 +19,9 @@
     "net45": { },
     "netstandard1.1": {
       "dependencies": {
-        "System.Linq": "4.1.0-rc2-24027",
-        "System.Threading": "4.0.11-rc2-24027",
-        "System.Collections.Concurrent": "4.0.12-rc2-24027"
+        "System.Linq": "4.1.0",
+        "System.Threading": "4.0.11",
+        "System.Collections.Concurrent": "4.0.12"
       }
     }
   }

--- a/test/MediatR.Tests/project.json
+++ b/test/MediatR.Tests/project.json
@@ -4,7 +4,7 @@
     "MediatR": { "target": "project" },
     "Shouldly": "2.7.0",
     "structuremap": "4.2.0.402",
-    "xunit": "2.1.0",
+    "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
 

--- a/test/MediatR.Tests/project.json
+++ b/test/MediatR.Tests/project.json
@@ -5,20 +5,20 @@
     "Shouldly": "2.7.0",
     "structuremap": "4.2.0.402",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc3-*"
+    "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
 
   "frameworks": {
     "net452": {
       "dependencies": {
-        "Microsoft.NETCore.Platforms": "1.0.1-rc2-24027"
+        "Microsoft.NETCore.Platforms": "1.0.1"
       }
     },
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002702"
+          "version": "1.0.0"
         }
       },
       "imports": [


### PR DESCRIPTION
Do you accept PRs to `master` as there's no `dev` branch?

Steps I took:

 - update SDK version in `global.json`
 - remove `-rc2-*` suffix for .NET Core provided dependencies
 - and then pretty much update other dependencies to the latest found version

I can build in VS and `dotnet test` passes.

Let me know if I missed anything.
Thanks