### PR TITLE
Add configurable cache and cache separately per TWrapper

### DIFF
--- a/src/MediatR/ITypeCache.cs
+++ b/src/MediatR/ITypeCache.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace MediatR
+{
+    public interface ITypeCache
+    {
+        Type GetGenericHandlerType<T, T1>(Type handlerType, Type requestType);
+        Type GetWrapperType<T, T1>(Type wrapperType, Type requestType);
+        Type GetGenericNotificationHandler<T>(Type handlerType, Type notificationType);
+        Type GetWrapperNotificationHandler<T>(Type wrapperType, Type notificationType);
+    }
+}

--- a/src/MediatR/StaticTypeCache.cs
+++ b/src/MediatR/StaticTypeCache.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace MediatR
+{
+    internal class StaticTypeCache : ITypeCache
+    {
+        private static readonly ConcurrentDictionary<Type, Type> GenericHandlerCache;
+        private static readonly ConcurrentDictionary<Type, Type> WrapperHandlerCache;
+
+        static StaticTypeCache() {
+            GenericHandlerCache = new ConcurrentDictionary<Type, Type>();
+            WrapperHandlerCache = new ConcurrentDictionary<Type, Type>();
+        }
+
+        public Type GetWrapperType<TWrapper, TResponse>(Type wrapperType, Type requestType) {
+            return WrapperHandlerCache.GetOrAdd(requestType, wrapperType, (type, root) => root.MakeGenericType(type, typeof(TResponse)));
+        }
+
+        public Type GetGenericHandlerType<TWrapper, TResponse>(Type handlerType, Type requestType) {
+            return GenericHandlerCache.GetOrAdd(requestType, handlerType, (type, root) => root.MakeGenericType(type, typeof(TResponse)));
+        }
+
+        public Type GetWrapperNotificationHandler<TWrapper>(Type wrapperType, Type notificationType) {
+            return Cache<TWrapper>.WrapperHandlerCache.GetOrAdd(notificationType, wrapperType, (type, root) => root.MakeGenericType(type));
+        }
+
+        public Type GetGenericNotificationHandler<TWrapper>(Type handlerType, Type notificationType) {
+            return GenericHandlerCache.GetOrAdd(notificationType, handlerType, (type, root) => root.MakeGenericType(type));
+        }
+
+        internal static class Cache<T>
+        {
+            internal static ConcurrentDictionary<Type, Type> WrapperHandlerCache { get; }
+
+            static Cache()
+            {
+                WrapperHandlerCache = new ConcurrentDictionary<Type, Type>();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Configurable cache and solution to #94. Defaults to a static cache currently.
I think it would be better to change the approach to a non static class though, as one could register a singleton cache if desired anyway.
