### PR TITLE
Added option to enable PublishAsync to invoke handlers sequentially

### DIFF
--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -21,7 +21,7 @@ namespace MediatR
         private readonly ConcurrentDictionary<Type, Type> _genericHandlerCache;
         private readonly ConcurrentDictionary<Type, Type> _wrapperHandlerCache;
 
-        private PublishAsyncOptions _publishOption;
+        private readonly PublishAsyncOptions _publishOption;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Mediator"/> class.
@@ -29,7 +29,7 @@ namespace MediatR
         /// <param name="singleInstanceFactory">The single instance factory.</param>
         /// <param name="multiInstanceFactory">The multi instance factory.</param>
         public Mediator(SingleInstanceFactory singleInstanceFactory, MultiInstanceFactory multiInstanceFactory) :
-            this(singleInstanceFactory, multiInstanceFactory, new MediatorConfiguration())
+            this(singleInstanceFactory, multiInstanceFactory, new MediatorConfiguration() { PublishAsyncOptions = PublishAsyncOptions.Parallel})
         {
         }
 
@@ -125,8 +125,7 @@ namespace MediatR
         private Task PublishParallelAsync(IAsyncNotification notification, IEnumerable<AsyncNotificationHandlerWrapper> notificationHandlers)
         {
             var tasks = notificationHandlers
-                .Select(handler => handler.Handle(notification))
-                .ToArray();
+                .Select(handler => handler.Handle(notification));
 
             return Task.WhenAll(tasks);
         }
@@ -135,8 +134,7 @@ namespace MediatR
             IEnumerable<CancellableAsyncNotificationHandlerWrapper> notificationHandlers)
         {
             var tasks = notificationHandlers
-                .Select(handler => handler.Handle(notification, cancellationToken))
-                .ToArray();
+                .Select(handler => handler.Handle(notification, cancellationToken));
 
             return Task.WhenAll(tasks);
         }

--- a/src/MediatR/MediatorConfiguration.cs
+++ b/src/MediatR/MediatorConfiguration.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MediatR
+{
+    public enum PublishAsyncOptions
+    {
+        Parallel,
+        Sequential
+    }
+
+    public class MediatorConfiguration
+    {
+        public PublishAsyncOptions PublishAsyncOptions { get; set; } = PublishAsyncOptions.Parallel;
+    }
+}


### PR DESCRIPTION
This helps to address #98 by adding a configuration option to enable invoking async notification handlers sequentially rather than in parallel.
