### PR TITLE
Use 'IKernel.TryGet' instead of 'IKernel.Get' to avoid catching excep…

### DIFF
--- a/samples/MediatR.Examples.Ninject/Program.cs
+++ b/samples/MediatR.Examples.Ninject/Program.cs
@@ -24,7 +24,7 @@
             kernel.Bind(scan => scan.FromAssemblyContaining<IMediator>().SelectAllClasses().BindDefaultInterface());
             kernel.Bind(scan => scan.FromAssemblyContaining<Ping>().SelectAllClasses().BindAllInterfaces());
             kernel.Bind<TextWriter>().ToConstant(Console.Out);
-            kernel.Bind<SingleInstanceFactory>().ToMethod(ctx => t => ctx.Kernel.Get(t));
+            kernel.Bind<SingleInstanceFactory>().ToMethod(ctx => t => ctx.Kernel.TryGet(t));
             kernel.Bind<MultiInstanceFactory>().ToMethod(ctx => t => ctx.Kernel.GetAll(t));
 
             var mediator = kernel.Get<IMediator>();


### PR DESCRIPTION
…tions while debugging.

MediatR 3 tries to get all three variants of a request handler (sync / async/ cancellable async). 

This is done inside a try/catch in case the container throws. See: https://github.com/jbogard/MediatR/blob/master/src/MediatR/Internal/RequestHandler.cs#L14

But because the container configuration is user-code, while debugging, the VS debugger while still break on these exceptions.

Annotating the method with [DebuggerNonUserCode] attribute does not work since VS 2015 U2, because of performance optimizations in de debugger.

This PR changes the NInject sample to use 'TryGet' instead of 'Get', so it returns null instead of throwing an exception when a valid binding is not found for the requested handler type.
