### PR TITLE
Expose exceptions that occurred while resolving handlers

### DIFF
--- a/src/MediatR/Internal/RequestHandler.cs
+++ b/src/MediatR/Internal/RequestHandler.cs
@@ -63,7 +63,7 @@ namespace MediatR.Internal
             var initialized = false;
 
             LazyInitializer.EnsureInitialized(ref _handlerFactory, ref initialized, ref _syncLock,
-                () => GetHandlerFactory(t => GetHandler(t, factory)));
+                () => GetHandlerFactory(factory));
 
             if (!initialized || _handlerFactory == null)
             {
@@ -136,7 +136,7 @@ namespace MediatR.Internal
             var initialized = false;
 
             LazyInitializer.EnsureInitialized(ref _handlerFactory, ref initialized, ref _syncLock,
-                () => GetHandlerFactory(t => GetHandler(t, singleInstanceFactory)));
+                () => GetHandlerFactory(singleInstanceFactory));
 
             if (!initialized || _handlerFactory == null)
             {


### PR DESCRIPTION
This pull requests adds caching of the exceptions that occurred while resolving handlers. If no handler was resolved, the exceptions are used as `innerException` for the exception already thrown.

Honestly I'm not sure if this is desired behavior, personally I'd favor that the `singleInstanceFactory` should only exception on issues during resolve and return `null` if no handler was registered. In that case this commit is total nonsense and only the try/catch in `GetHandler(...)` should be removed.

The pull request also features a small fix to `GetHandler(...)` being applied twice.