### PR TITLE
Apply ConfigureAwait(false) on all awaits

### DIFF
--- a/src/MediatR/Internal/RequestHandler.cs
+++ b/src/MediatR/Internal/RequestHandler.cs
@@ -187,7 +187,7 @@ namespace MediatR.Internal
                 return (request, token, fac) => async () =>
                 {
                     var handler = GetHandler<IAsyncRequestHandler<TRequest>>(fac);
-                    await handler.Handle(request);
+                    await handler.Handle(request).ConfigureAwait(false);
                     return Unit.Value;
                 };
             }
@@ -196,7 +196,7 @@ namespace MediatR.Internal
                 return (request, token, fac) => async () =>
                 {
                     var handler = GetHandler<ICancellableAsyncRequestHandler<TRequest>>(fac);
-                    await handler.Handle(request, token);
+                    await handler.Handle(request, token).ConfigureAwait(false);
                     return Unit.Value;
                 };
             }

--- a/src/MediatR/Pipeline/RequestPostProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestPostProcessorBehavior.cs
@@ -20,9 +20,9 @@
 
         public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next)
         {
-            var response = await next();
+            var response = await next().ConfigureAwait(false);
 
-            await Task.WhenAll(_postProcessors.Select(p => p.Process(request, response)));
+            await Task.WhenAll(_postProcessors.Select(p => p.Process(request, response))).ConfigureAwait(false);
 
             return response;
         }

--- a/src/MediatR/Pipeline/RequestPreProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestPreProcessorBehavior.cs
@@ -20,9 +20,9 @@
 
         public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next)
         {
-            await Task.WhenAll(_preProcessors.Select(p => p.Process(request)));
+            await Task.WhenAll(_preProcessors.Select(p => p.Process(request))).ConfigureAwait(false);
 
-            return await next();
+            return await next().ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
Pull request for #137

See https://msdn.microsoft.com/en-us/magazine/jj991977.aspx for
information regarding async/await. Pipeline behavior that was expecting
to run on the SynchronizationContext that the IMediator call was made
from will now have to take care of the switch back to the original
SynchronizationContext. Some examples of doing that can be found at
https://blogs.msdn.microsoft.com/pfxteam/2011/01/13/await-anything/.