### PR TITLE
Same type version for all request handlers

### DIFF
--- a/samples/MediatR.Examples.StructureMap/Program.cs
+++ b/samples/MediatR.Examples.StructureMap/Program.cs
@@ -26,7 +26,7 @@
                     scanner.WithDefaultConventions();
                     scanner.ConnectImplementationsToTypesClosing(typeof(IRequestHandler<,>));
                     scanner.ConnectImplementationsToTypesClosing(typeof(IAsyncRequestHandler<,>));
-                    scanner.ConnectImplementationsToTypesClosing(typeof(ICancellableAsyncRequestHandler<>));
+                    scanner.ConnectImplementationsToTypesClosing(typeof(ICancellableAsyncRequestHandler<,>));
                     scanner.ConnectImplementationsToTypesClosing(typeof(INotificationHandler<>));
                     scanner.ConnectImplementationsToTypesClosing(typeof(IAsyncNotificationHandler<>));
                     scanner.ConnectImplementationsToTypesClosing(typeof(ICancellableAsyncNotificationHandler<>));


### PR DESCRIPTION
Initially, I got confused because I did not notice that only the ICancellableAsyncRequestHandler with a single type argument (Task return) was scanned. I wonder if it is better to either register all two arguments versions of request handlers or to drop all cancellable version of handlers as they are not used in the example. Another option could be to register all single type arguments of request handlers as well.