### PR TITLE
Fix Ninject sample to bind IRequestHandlers without a TResponse

### DIFF
--- a/samples/MediatR.Examples.Ninject/Program.cs
+++ b/samples/MediatR.Examples.Ninject/Program.cs
@@ -27,8 +27,11 @@ namespace MediatR.Examples.Ninject
             kernel.Bind<TextWriter>().ToConstant(Console.Out);
 
             kernel.Bind(scan => scan.FromAssemblyContaining<Ping>().SelectAllClasses().InheritedFrom(typeof(IRequestHandler<,>)).BindAllInterfaces());
+             kernel.Bind(scan => scan.FromAssemblyContaining<Ping>().SelectAllClasses().InheritedFrom(typeof(IRequestHandler<>)).BindAllInterfaces());
             kernel.Bind(scan => scan.FromAssemblyContaining<Ping>().SelectAllClasses().InheritedFrom(typeof(IAsyncRequestHandler<,>)).BindAllInterfaces());
+            kernel.Bind(scan => scan.FromAssemblyContaining<Ping>().SelectAllClasses().InheritedFrom(typeof(IAsyncRequestHandler<>)).BindAllInterfaces());
             kernel.Bind(scan => scan.FromAssemblyContaining<Ping>().SelectAllClasses().InheritedFrom(typeof(ICancellableAsyncRequestHandler<,>)).BindAllInterfaces());
+            kernel.Bind(scan => scan.FromAssemblyContaining<Ping>().SelectAllClasses().InheritedFrom(typeof(ICancellableAsyncRequestHandler<>)).BindAllInterfaces());
             kernel.Bind(scan => scan.FromAssemblyContaining<Ping>().SelectAllClasses().InheritedFrom(typeof(INotificationHandler<>)).BindAllInterfaces());
             kernel.Bind(scan => scan.FromAssemblyContaining<Ping>().SelectAllClasses().InheritedFrom(typeof(IAsyncNotificationHandler<>)).BindAllInterfaces());
             kernel.Bind(scan => scan.FromAssemblyContaining<Ping>().SelectAllClasses().InheritedFrom(typeof(ICancellableAsyncNotificationHandler<>)).BindAllInterfaces());


### PR DESCRIPTION
- Updated Ninject sample

The current sample doesn't bind `IRequestHandler<TRequest>` handlers, only `IRequestHandler<TRequest, TResponse>` handlers. Tripped me up for a good 30 minutes 👍 