### PR TITLE
Fix NuGet deployment

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -22,7 +22,7 @@ function Exec
     }
 }
 
-if(Test-Path .\artifacts) { Remove-Item .\artifacts -Force -Recurse }
+if(Test-Path .\artifacts) { Remove-Item .\src\MediatR\artifacts -Force -Recurse }
 
 exec { & dotnet restore }
 

--- a/Build.ps1
+++ b/Build.ps1
@@ -22,7 +22,7 @@ function Exec
     }
 }
 
-if(Test-Path .\artifacts) { Remove-Item .\src\MediatR\artifacts -Force -Recurse }
+if(Test-Path .\src\MediatR\artifacts) { Remove-Item .\src\MediatR\artifacts -Force -Recurse }
 
 exec { & dotnet restore }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ build_script:
 - ps: .\Build.ps1
 test: off
 artifacts:
-- path: .\artifacts\**\*.nupkg
+- path: .\src\MediatR\artifacts\**\*.nupkg
   name: NuGet
 deploy:
 - provider: NuGet

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,6 @@
 ﻿version: '{build}'
 pull_requests:
   do_not_increment_build_number: true
-branches:
-  only:
-  - master
 image: Visual Studio 2017
 nuget:
   disable_publish_on_pr: true
@@ -26,5 +23,4 @@ deploy:
   api_key:
     secure: t3blEIQiDIYjjWhOSTTtrcAnzJkmSi+0zYPxC1v4RDzm6oI/gIpD6ZtrOGsYu2jE
   on:
-    branch: master
     appveyor_repo_tag: true


### PR DESCRIPTION
According to Appveyor's docs, we need to use either "on branch" or "on appveyor_repo_tag".

More info on: https://www.appveyor.com/docs/branches/

Also, the path to artifacts was incorrect. Apparently when you execute "dotnet pack -o .\artifacts" it just creates an "artifacts" folder inside of the project's folder.