### PR TITLE
Include build support for netstandard2.0

### DIFF
--- a/src/MediatR/MediatR.csproj
+++ b/src/MediatR/MediatR.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright Jimmy Bogard</Copyright>
     <VersionPrefix>3.1.0</VersionPrefix>
     <Authors>Jimmy Bogard</Authors>
-    <TargetFrameworks>net45;netstandard1.1</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.1;netstandard2.0</TargetFrameworks>
     <AssemblyName>MediatR</AssemblyName>
     <PackageId>MediatR</PackageId>
     <PackageTags>mediator;request;response;queries;commands;notifications</PackageTags>


### PR DESCRIPTION
I simply added netstandard2.0 to the list of TargetFrameworks for the main project so I can use it on .NET Core 2