### PR TITLE
- adds contextual notification/request handlers

### DIFF
--- a/samples/MediatR.Examples.SimpleInjector/Program.cs
+++ b/samples/MediatR.Examples.SimpleInjector/Program.cs
@@ -28,9 +28,11 @@ namespace MediatR.Examples.SimpleInjector
 			container.Register(typeof(IRequestHandler<>), assemblies);
             container.Register(typeof(IAsyncRequestHandler<>), assemblies);
             container.Register(typeof(ICancellableAsyncRequestHandler<>), assemblies);
+            container.Register(typeof(IContextualAsyncRequestHandler<>), assemblies);
             container.RegisterCollection(typeof(INotificationHandler<>), assemblies);
             container.RegisterCollection(typeof(IAsyncNotificationHandler<>), assemblies);
             container.RegisterCollection(typeof(ICancellableAsyncNotificationHandler<>), assemblies);
+            container.RegisterCollection(typeof(IContextualAsyncNotificationHandler<>), assemblies);
             container.RegisterSingleton(Console.Out);
 
             //Pipeline

--- a/samples/MediatR.Examples/GenericPipelineBehavior.cs
+++ b/samples/MediatR.Examples/GenericPipelineBehavior.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace MediatR.Examples
@@ -12,12 +12,13 @@ namespace MediatR.Examples
             _writer = writer;
         }
 
-        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next)
+        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, IMediatorContext context)
         {
             _writer.WriteLine("-- Handling Request");
             var response = await next();
             _writer.WriteLine("-- Finished Request");
             return response;
         }
+        
     }
 }

--- a/samples/MediatR.Examples/GenericRequestPostProcessor.cs
+++ b/samples/MediatR.Examples/GenericRequestPostProcessor.cs
@@ -13,7 +13,7 @@ namespace MediatR.Examples
             _writer = writer;
         }
 
-        public Task Process(TRequest request, TResponse response)
+        public Task Process(TRequest request, TResponse response,IMediatorContext context)
         {
             _writer.WriteLine("- All Done");
             return Task.FromResult(0);

--- a/samples/MediatR.Examples/GenericRequestPreProcessor.cs
+++ b/samples/MediatR.Examples/GenericRequestPreProcessor.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Threading.Tasks;
 using MediatR.Pipeline;
 
@@ -13,7 +13,7 @@ namespace MediatR.Examples
             _writer = writer;
         }
 
-        public Task Process(TRequest request)
+        public Task Process(TRequest request, IMediatorContext context)
         {
             _writer.WriteLine("- Starting Up");
             return Task.FromResult(0);

--- a/samples/MediatR.Examples/PingAsyncHandler.cs
+++ b/samples/MediatR.Examples/PingAsyncHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 
 namespace MediatR.Examples
 {

--- a/samples/MediatR.Examples/PingedAsyncHandler.cs
+++ b/samples/MediatR.Examples/PingedAsyncHandler.cs
@@ -1,9 +1,9 @@
-﻿namespace MediatR.Examples
+namespace MediatR.Examples
 {
     using System.IO;
     using System.Threading.Tasks;
 
-    public class PingedAsyncHandler : IAsyncNotificationHandler<PingedAsync>
+    public class PingedAsyncHandler : IContextualAsyncNotificationHandler<PingedAsync>
     {
         private readonly TextWriter _writer;
 
@@ -12,9 +12,9 @@
             _writer = writer;
         }
 
-        public Task Handle(PingedAsync notification)
+        public Task Handle(PingedAsync notification,IMediatorContext context)
         {
-            return _writer.WriteLineAsync("Got pinged async.");
+            return _writer.WriteLineAsync($"--- Got pinged async. {context?.Items["created-at"]}");
         }
     }
 
@@ -29,7 +29,7 @@
 
         public Task Handle(PingedAsync notification)
         {
-            return _writer.WriteLineAsync("Got pinged also async.");
+            return _writer.WriteLineAsync("--- Got pinged also async.");
         }
     }
 }

--- a/samples/MediatR.Examples/PingedHandler.cs
+++ b/samples/MediatR.Examples/PingedHandler.cs
@@ -1,4 +1,4 @@
-﻿namespace MediatR.Examples
+namespace MediatR.Examples
 {
     using System.IO;
 

--- a/samples/MediatR.Examples/Runner.cs
+++ b/samples/MediatR.Examples/Runner.cs
@@ -1,4 +1,8 @@
-﻿namespace MediatR.Examples
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace MediatR.Examples
 {
     using System.IO;
     using System.Threading.Tasks;
@@ -23,7 +27,14 @@
             await mediator.Publish(new Pinged());
 
             await writer.WriteLineAsync("Publishing Pinged async...");
-            await mediator.Publish(new PingedAsync());
+            var context = new DefaultMediatorContext()
+                                         {
+                                             Items = new Dictionary<object, object>()
+                                                     {
+                                                         {"created-at",DateTime.UtcNow}
+                                                     }
+                                         };
+            await mediator.Publish(new PingedAsync(), context: context);
         }
     }
 }

--- a/src/MediatR/DefaultMediatorContext.cs
+++ b/src/MediatR/DefaultMediatorContext.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Threading;
+
+namespace MediatR
+{
+    /// <summary>
+    /// Default Context
+    /// </summary>
+    public class DefaultMediatorContext
+        : IMediatorContext
+    {
+        public CancellationToken CancellationToken { get; set; } = default(CancellationToken);
+        public IDictionary<object, object> Items { get; set; }
+    }
+}

--- a/src/MediatR/IContextualAsyncNotificationHandler.cs
+++ b/src/MediatR/IContextualAsyncNotificationHandler.cs
@@ -1,20 +1,20 @@
-using System.Collections;
 using System.Threading.Tasks;
 
 namespace MediatR
 {
     /// <summary>
-    /// Defines an asynchronous handler for a notification
+    /// Defines a context supported, asynchronous handler for a notification
     /// </summary>
     /// <typeparam name="TNotification">The type of notification being handled</typeparam>
-    public interface IAsyncNotificationHandler<in TNotification>
+    public interface IContextualAsyncNotificationHandler<in TNotification>
         where TNotification : INotification
     {
         /// <summary>
         /// Handles an asynchronous notification
         /// </summary>
         /// <param name="notification">The notification message</param>
+        /// <param name="context">The context</param>
         /// <returns>A task representing handling the notification</returns>
-        Task Handle(TNotification notification);
+        Task Handle(TNotification notification, IMediatorContext context);
     }
 }

--- a/src/MediatR/IContextualAsyncRequestHandler.cs
+++ b/src/MediatR/IContextualAsyncRequestHandler.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MediatR
+{
+    /// <summary>
+    /// Defines a context supported, asynchronous handler for a request
+    /// </summary>
+    /// <typeparam name="TRequest">The type of request being handled</typeparam>
+    /// <typeparam name="TResponse">The type of response from the handler</typeparam>
+    public interface IContextualAsyncRequestHandler<in TRequest, TResponse>
+        where TRequest : IRequest<TResponse>
+    {
+        /// <summary>
+        /// Handles a cancellable, asynchronous request
+        /// </summary>
+        /// <param name="message">The request message</param>
+        /// <param name="context">Context</param>
+        /// <returns>A task representing the response from the request</returns>
+        Task<TResponse> Handle(TRequest message, IMediatorContext context);
+    }
+    /// <summary>
+    /// Defines a context supported, asynchronous handler for a request without a response
+    /// </summary>
+    /// <typeparam name="TRequest">The type of request being handled</typeparam>
+    public interface IContextualAsyncRequestHandler<in TRequest>
+        where TRequest : IRequest
+    {
+        /// <summary>
+        /// Handles a cancellable, asynchronous request
+        /// </summary>
+        /// <param name="message">The request message</param>
+        /// <param name="context">Context</param>
+        Task Handle(TRequest message, IMediatorContext context);
+    }
+}

--- a/src/MediatR/IMediator.cs
+++ b/src/MediatR/IMediator.cs
@@ -14,24 +14,27 @@ namespace MediatR
         /// <typeparam name="TResponse">Response type</typeparam>
         /// <param name="request">Request object</param>
         /// <param name="cancellationToken">Optional cancellation token</param>
+        /// <param name="context">Context</param>
         /// <returns>A task that represents the send operation. The task result contains the handler response</returns>
-        Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default(CancellationToken), IMediatorContext context = null);
 
         /// <summary>
         /// Asynchronously send a request to a single handler without expecting a response
         /// </summary>
         /// <param name="request">Request object</param>
         /// <param name="cancellationToken">Optional cancellation token</param>
+        /// <param name="context">Context</param>
         /// <returns>A task that represents the send operation.</returns>
-        Task Send(IRequest request, CancellationToken cancellationToken = default(CancellationToken));
+        Task Send(IRequest request, CancellationToken cancellationToken = default(CancellationToken), IMediatorContext context = null);
 
         /// <summary>
         /// Asynchronously send a notification to multiple handlers
         /// </summary>
         /// <param name="notification">Notification object</param>
         /// <param name="cancellationToken">Optional cancellation token</param>
+        /// <param name="context">Context</param>
         /// <returns>A task that represents the publish operation.</returns>
-        Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default(CancellationToken))
+        Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default(CancellationToken), IMediatorContext context = null)
             where TNotification : INotification;
     }
 }

--- a/src/MediatR/IMediatorContext.cs
+++ b/src/MediatR/IMediatorContext.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Threading;
+
+namespace MediatR
+{
+    /// <summary>
+    /// Context
+    /// </summary>
+    public interface IMediatorContext
+    {
+        /// <summary>
+        /// Cancellation Token
+        /// </summary>
+        CancellationToken CancellationToken { get; set; }
+
+        /// <summary>
+        ///  Gets or sets a key/value collection that can be used to share data within the scope of this request/notification.
+        /// </summary>
+        IDictionary<object, object> Items { get; set; }
+    }
+}

--- a/src/MediatR/IPipelineBehavior.cs
+++ b/src/MediatR/IPipelineBehavior.cs
@@ -1,4 +1,4 @@
-﻿namespace MediatR
+namespace MediatR
 {
     using System.Threading.Tasks;
 
@@ -22,7 +22,21 @@
         /// </summary>
         /// <param name="request">Incoming request</param>
         /// <param name="next">Awaitable delegate for the next action in the pipeline. Eventually this delegate represents the handler.</param>
+        /// <param name="context">The context</param>
         /// <returns>Awaitable task returning the <typeparamref name="TResponse"/></returns>
-        Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next);
+        Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, IMediatorContext context = null);
+    }
+
+
+    public interface INotificationPipelineBehaviour<in TRequest>
+    {
+        /// <summary>
+        /// Pipeline handler. Perform any additional behavior and await the <paramref name="next"/> delegate as necessary
+        /// </summary>
+        /// <param name="request">Incoming request</param>
+        /// <param name="next">Awaitable delegate for the next action in the pipeline. Eventually this delegate represents the handler.</param>
+        /// <param name="context">The context</param>
+        /// <returns>Awaitable task returning the <typeparamref name="TResponse"/></returns>
+        Task Handle(TRequest request, RequestHandlerDelegate<Unit> next, IMediatorContext context = null);
     }
 }

--- a/src/MediatR/Internal/NotificationHandler.cs
+++ b/src/MediatR/Internal/NotificationHandler.cs
@@ -8,16 +8,43 @@ namespace MediatR.Internal
 
     internal abstract class NotificationHandler
     {
-        public abstract Task Handle(INotification notification, CancellationToken cancellationToken, MultiInstanceFactory multiInstanceFactory, Func<IEnumerable<Task>, Task> publish);
+        public abstract Task Handle(INotification notification, CancellationToken cancellationToken, IMediatorContext context, MultiInstanceFactory multiInstanceFactory, Func<IEnumerable<Task>, Task> publish);
     }
 
     internal class NotificationHandlerImpl<TNotification> : NotificationHandler
         where TNotification : INotification
     {
-        public override Task Handle(INotification notification, CancellationToken cancellationToken, MultiInstanceFactory multiInstanceFactory, Func<IEnumerable<Task>, Task> publish)
+        public override Task Handle(INotification notification, CancellationToken cancellationToken, IMediatorContext context, MultiInstanceFactory multiInstanceFactory, Func<IEnumerable<Task>, Task> publish)
         {
-            var handlers = GetHandlers((TNotification)notification, cancellationToken, multiInstanceFactory);
-            return publish(handlers);
+            var handlers = GetHandlers((TNotification)notification, cancellationToken, context, multiInstanceFactory);
+            var pipeline = GetPipeline((TNotification)notification, context, handlers, multiInstanceFactory, publish);
+
+            return pipeline;
+            //return publish(handlers);
+        }
+
+        private static async Task<Unit> GetPipeline(TNotification request, IMediatorContext context, IEnumerable<RequestHandlerDelegate<Unit>> handlers, MultiInstanceFactory factory, Func<IEnumerable<Task>, Task> publish)
+        {
+            var behaviors = factory(typeof(IPipelineBehavior<TNotification, Unit>))
+                .Cast<IPipelineBehavior<TNotification, Unit>>()
+                .Reverse()
+                .ToArray();
+
+            var tasks = new List<Task<Unit>>();
+            foreach (var handle in handlers)
+            {
+                RequestHandlerDelegate<Unit> x = async () =>
+                {
+                    await handle();
+                    return Unit.Value;
+                };
+                var aggregate = behaviors.Aggregate(x, (next, pipeline) => () => pipeline.Handle(request, next, context));
+                tasks.Add(aggregate());
+            }
+
+            await Task.WhenAll(tasks);
+
+            return Unit.Value;
         }
 
         private static IEnumerable<THandler> GetHandlers<THandler>(MultiInstanceFactory factory)
@@ -25,26 +52,59 @@ namespace MediatR.Internal
             return factory(typeof(THandler)).Cast<THandler>();
         }
 
-        private IEnumerable<Task> GetHandlers(TNotification notification, CancellationToken cancellationToken, MultiInstanceFactory factory)
+        private IEnumerable<RequestHandlerDelegate<Unit>> GetHandlers(TNotification notification, CancellationToken cancellationToken, IMediatorContext context, MultiInstanceFactory factory)
         {
             var notificationHandlers = GetHandlers<INotificationHandler<TNotification>>(factory)
                 .Select(x =>
                     {
-                        x.Handle(notification);
-                        return Unit.Task;
+                        return new RequestHandlerDelegate<Unit>(() =>
+                        {
+                            x.Handle(notification);
+                            return Task.FromResult(Unit.Value);
+                        });
                     });
 
             var asyncNotificationHandlers = GetHandlers<IAsyncNotificationHandler<TNotification>>(factory)
-                .Select(x => x.Handle(notification));
+                .Select(x =>
+               {
+                   return new RequestHandlerDelegate<Unit>(async () =>
+                   {
+                       await x.Handle(notification).ConfigureAwait(false);
+                       return Unit.Value;
+                   });
+               });
 
             var cancellableAsyncNotificationHandlers = GetHandlers<ICancellableAsyncNotificationHandler<TNotification>>(factory)
-                .Select(x => x.Handle(notification, cancellationToken));
+                    .Select( x =>
+                   {
+                       return new RequestHandlerDelegate<Unit>(async () =>
+                       {
+                           await x.Handle(notification, cancellationToken).ConfigureAwait(false);
+                           return Unit.Value;
+                       });
+                   });
+
+            var contextualAsyncNotificationHandlers = GetHandlers<IContextualAsyncNotificationHandler<TNotification>>(factory)
+                .Select( x =>
+                {
+                    return new RequestHandlerDelegate<Unit>(async () =>
+                    {
+                        await x.Handle(notification, context).ConfigureAwait(false);
+                        return Unit.Value;
+                    });
+                });
 
             var allHandlers = notificationHandlers
                 .Concat(asyncNotificationHandlers)
-                .Concat(cancellableAsyncNotificationHandlers);
+                .Concat(cancellableAsyncNotificationHandlers)
+                .Concat(contextualAsyncNotificationHandlers);
 
             return allHandlers;
+        }
+
+        private Task<Unit> RequestHandlerDelegate()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -29,37 +29,41 @@ namespace MediatR
             _multiInstanceFactory = multiInstanceFactory;
         }
 
-        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default(CancellationToken),IMediatorContext context=null)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
+
+            context = SetDefaultContext(cancellationToken, context);
 
             var requestType = request.GetType();
 
             var handler = (RequestHandler<TResponse>)_requestHandlers.GetOrAdd(requestType,
                 t => Activator.CreateInstance(typeof(RequestHandlerImpl<,>).MakeGenericType(requestType, typeof(TResponse))));
 
-            return handler.Handle(request, cancellationToken, _singleInstanceFactory, _multiInstanceFactory);
+            return handler.Handle(request, cancellationToken,context, _singleInstanceFactory, _multiInstanceFactory);
         }
 
-        public Task Send(IRequest request, CancellationToken cancellationToken = default(CancellationToken))
+        public Task Send(IRequest request, CancellationToken cancellationToken = default(CancellationToken), IMediatorContext context = null)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
+            context = SetDefaultContext(cancellationToken, context);
+
             var requestType = request.GetType();
 
             var handler = _voidRequestHandlers.GetOrAdd(requestType,
-                t => (RequestHandler) Activator.CreateInstance(typeof(RequestHandlerImpl<>).MakeGenericType(requestType)));
+                t => (RequestHandler)Activator.CreateInstance(typeof(RequestHandlerImpl<>).MakeGenericType(requestType)));
 
-            return handler.Handle(request, cancellationToken, _singleInstanceFactory, _multiInstanceFactory);
+            return handler.Handle(request, cancellationToken,context, _singleInstanceFactory, _multiInstanceFactory);
         }
 
-        public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default(CancellationToken))
+        public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default(CancellationToken), IMediatorContext context = null)
             where TNotification : INotification
         {
             if (notification == null)
@@ -67,11 +71,23 @@ namespace MediatR
                 throw new ArgumentNullException(nameof(notification));
             }
 
+            context = SetDefaultContext(cancellationToken, context);
+
             var notificationType = notification.GetType();
             var handler = _notificationHandlers.GetOrAdd(notificationType,
                 t => (NotificationHandler)Activator.CreateInstance(typeof(NotificationHandlerImpl<>).MakeGenericType(notificationType)));
 
-            return handler.Handle(notification, cancellationToken, _multiInstanceFactory, PublishCore);
+            return handler.Handle(notification, cancellationToken, context, _multiInstanceFactory, PublishCore);
+        }
+
+        private static IMediatorContext SetDefaultContext(CancellationToken cancellationToken, IMediatorContext context)
+        {
+            context = context ?? new DefaultMediatorContext();
+            if (context.CancellationToken == default(CancellationToken))
+            {
+                context.CancellationToken = cancellationToken;
+            }
+            return context;
         }
 
         /// <summary>

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace MediatR
 {
     using Internal;
@@ -29,7 +31,7 @@ namespace MediatR
             _multiInstanceFactory = multiInstanceFactory;
         }
 
-        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default(CancellationToken),IMediatorContext context=null)
+        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default(CancellationToken), IMediatorContext context = null)
         {
             if (request == null)
             {
@@ -43,7 +45,7 @@ namespace MediatR
             var handler = (RequestHandler<TResponse>)_requestHandlers.GetOrAdd(requestType,
                 t => Activator.CreateInstance(typeof(RequestHandlerImpl<,>).MakeGenericType(requestType, typeof(TResponse))));
 
-            return handler.Handle(request, cancellationToken,context, _singleInstanceFactory, _multiInstanceFactory);
+            return handler.Handle(request, cancellationToken, context, _singleInstanceFactory, _multiInstanceFactory);
         }
 
         public Task Send(IRequest request, CancellationToken cancellationToken = default(CancellationToken), IMediatorContext context = null)
@@ -60,7 +62,7 @@ namespace MediatR
             var handler = _voidRequestHandlers.GetOrAdd(requestType,
                 t => (RequestHandler)Activator.CreateInstance(typeof(RequestHandlerImpl<>).MakeGenericType(requestType)));
 
-            return handler.Handle(request, cancellationToken,context, _singleInstanceFactory, _multiInstanceFactory);
+            return handler.Handle(request, cancellationToken, context, _singleInstanceFactory, _multiInstanceFactory);
         }
 
         public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default(CancellationToken), IMediatorContext context = null)
@@ -95,9 +97,9 @@ namespace MediatR
         /// </summary>
         /// <param name="allHandlers">Enumerable of tasks representing invoking each notification handler</param>
         /// <returns>A task representing invoking all handlers</returns>
-        protected virtual Task PublishCore(IEnumerable<Task> allHandlers)
+        protected virtual Task PublishCore(IEnumerable<RequestHandlerDelegate<Unit>> allHandlers)
         {
-            return Task.WhenAll(allHandlers);
+            return Task.WhenAll(allHandlers.Select(d => d()));
         }
     }
 }

--- a/src/MediatR/Pipeline/IRequestPostProcessor.cs
+++ b/src/MediatR/Pipeline/IRequestPostProcessor.cs
@@ -1,4 +1,4 @@
-﻿namespace MediatR.Pipeline
+namespace MediatR.Pipeline
 {
     using System.Threading.Tasks;
 
@@ -14,7 +14,8 @@
         /// </summary>
         /// <param name="request">Request instance</param>
         /// <param name="response">Response instance</param>
+        /// <param name="context">The context</param>
         /// <returns>An awaitable task</returns>
-        Task Process(TRequest request, TResponse response);
+        Task Process(TRequest request, TResponse response,IMediatorContext context);
     }
 }

--- a/src/MediatR/Pipeline/IRequestPreProcessor.cs
+++ b/src/MediatR/Pipeline/IRequestPreProcessor.cs
@@ -1,4 +1,4 @@
-﻿namespace MediatR.Pipeline
+namespace MediatR.Pipeline
 {
     using System.Threading.Tasks;
 
@@ -12,7 +12,8 @@
         /// Process method executes before calling the Handle method on your handler
         /// </summary>
         /// <param name="request">Incoming request</param>
+        /// <param name="context">The context</param>
         /// <returns>An awaitable task</returns>
-        Task Process(TRequest request);
+        Task Process(TRequest request,IMediatorContext context);
     }
 }

--- a/src/MediatR/Pipeline/RequestPostProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestPostProcessorBehavior.cs
@@ -18,13 +18,14 @@ namespace MediatR.Pipeline
             _postProcessors = postProcessors;
         }
 
-        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next)
+        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, IMediatorContext context)
         {
             var response = await next().ConfigureAwait(false);
 
-            await Task.WhenAll(_postProcessors.Select(p => p.Process(request, response))).ConfigureAwait(false);
+            await Task.WhenAll(_postProcessors.Select(p => p.Process(request, response,context))).ConfigureAwait(false);
 
             return response;
         }
+        
     }
 }

--- a/src/MediatR/Pipeline/RequestPreProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestPreProcessorBehavior.cs
@@ -1,4 +1,4 @@
-﻿namespace MediatR.Pipeline
+namespace MediatR.Pipeline
 {
     using System.Collections.Generic;
     using System.Linq;
@@ -18,9 +18,9 @@
             _preProcessors = preProcessors;
         }
 
-        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next)
+        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, IMediatorContext context)
         {
-            await Task.WhenAll(_preProcessors.Select(p => p.Process(request))).ConfigureAwait(false);
+            await Task.WhenAll(_preProcessors.Select(p => p.Process(request,context))).ConfigureAwait(false);
 
             return await next().ConfigureAwait(false);
         }

--- a/test/MediatR.Tests/AsyncPublishTests.cs
+++ b/test/MediatR.Tests/AsyncPublishTests.cs
@@ -1,4 +1,4 @@
-﻿namespace MediatR.Tests
+namespace MediatR.Tests
 {
     using System;
     using System.Collections.Generic;
@@ -84,11 +84,11 @@
             {
             }
 
-            protected override async Task PublishCore(IEnumerable<Task> allHandlers)
+            protected override async Task PublishCore(IEnumerable<RequestHandlerDelegate<Unit>> allHandlers)
             {
                 foreach (var handler in allHandlers)
                 {
-                    await handler;
+                    await handler();
                 }
             }
         }

--- a/test/MediatR.Tests/Pipeline/RequestPostProcessorTests.cs
+++ b/test/MediatR.Tests/Pipeline/RequestPostProcessorTests.cs
@@ -1,4 +1,4 @@
-﻿namespace MediatR.Tests.Pipeline
+namespace MediatR.Tests.Pipeline
 {
     using System.Threading.Tasks;
     using MediatR.Pipeline;
@@ -28,7 +28,7 @@
 
         public class PingPongPostProcessor : IRequestPostProcessor<Ping, Pong>
         {
-            public Task Process(Ping request, Pong response)
+            public Task Process(Ping request, Pong response,IMediatorContext context)
             {
                 response.Message = response.Message + " " + request.Message;
 

--- a/test/MediatR.Tests/Pipeline/RequestPreProcessorTests.cs
+++ b/test/MediatR.Tests/Pipeline/RequestPreProcessorTests.cs
@@ -1,4 +1,4 @@
-﻿namespace MediatR.Tests.Pipeline
+namespace MediatR.Tests.Pipeline
 {
     using System.Threading.Tasks;
     using MediatR.Pipeline;
@@ -28,7 +28,7 @@
 
         public class PingPreProcessor : IRequestPreProcessor<Ping>
         {
-            public Task Process(Ping request)
+            public Task Process(Ping request, IMediatorContext context)
             {
                 request.Message = request.Message + " Ping";
 

--- a/test/MediatR.Tests/PipelineTests.cs
+++ b/test/MediatR.Tests/PipelineTests.cs
@@ -1,4 +1,4 @@
-﻿namespace MediatR.Tests
+namespace MediatR.Tests
 {
     using System;
     using System.Collections.Generic;
@@ -68,7 +68,7 @@
                 _output = output;
             }
 
-            public async Task<Pong> Handle(Ping request, RequestHandlerDelegate<Pong> next)
+            public async Task<Pong> Handle(Ping request, RequestHandlerDelegate<Pong> next, IMediatorContext context)
             {
                 _output.Messages.Add("Outer before");
                 var response = await next();
@@ -87,7 +87,7 @@
                 _output = output;
             }
 
-            public async Task<Pong> Handle(Ping request, RequestHandlerDelegate<Pong> next)
+            public async Task<Pong> Handle(Ping request, RequestHandlerDelegate<Pong> next, IMediatorContext context)
             {
                 _output.Messages.Add("Inner before");
                 var response = await next();
@@ -106,7 +106,7 @@
                 _output = output;
             }
 
-            public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next)
+            public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, IMediatorContext context)
             {
                 _output.Messages.Add("Inner generic before");
                 var response = await next();
@@ -125,7 +125,7 @@
                 _output = output;
             }
 
-            public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next)
+            public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, IMediatorContext context)
             {
                 _output.Messages.Add("Outer generic before");
                 var response = await next();
@@ -146,7 +146,7 @@
                 _output = output;
             }
 
-            public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next)
+            public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, IMediatorContext context)
             {
                 _output.Messages.Add("Constrained before");
                 var response = await next();
@@ -165,7 +165,7 @@
                 _output = output;
             }
 
-            public async Task<Pong> Handle(Ping request, RequestHandlerDelegate<Pong> next)
+            public async Task<Pong> Handle(Ping request, RequestHandlerDelegate<Pong> next, IMediatorContext context)
             {
                 _output.Messages.Add("Concrete before");
                 var response = await next();


### PR DESCRIPTION
- adds pipeline for notifications
- adds contextual notification/request handlers

You can pass data to handler like this:
```csharp
var context = new DefaultMediatorContext()
                                         {
                                             Items = new Dictionary<object, object>()
                                                     {
                                                         {"created-at",DateTime.UtcNow}
                                                     }
                                         };
await mediator.Publish(new PingedAsync(), context: context);
```
then you can access from handler:
```csharp
 public class PingedAsyncHandler : IContextualAsyncNotificationHandler<PingedAsync>
    {
        private readonly TextWriter _writer;

        public PingedAsyncHandler(TextWriter writer)
        {
            _writer = writer;
        }

        public Task Handle(PingedAsync notification,IMediatorContext context)
        {
            return _writer.WriteLineAsync($"--- Got pinged async. {context?.Items["created-at"]}");
        }
    }
```
