### PR TITLE
Added 2  new Send method overloads

### DIFF
--- a/src/MediatR/IMediator.cs
+++ b/src/MediatR/IMediator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -18,12 +19,31 @@ namespace MediatR
         Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
+        /// Asynchronously send a request to a single handler
+        /// </summary>
+        /// <typeparam name="TRequest">Request type</typeparam>
+        /// <typeparam name="TResponse">Response type</typeparam>
+        /// <param name="request">Request object</param>
+        /// <param name="cancellationToken">Optional cancellation token</param>
+        /// <returns>A task that represents the send operation. The task result contains the handler response</returns>
+        Task<TResponse> Send<TRequest, TResponse>(TRequest request, CancellationToken cancellationToken = default(CancellationToken)) where TRequest : IRequest<TResponse>;
+        
+        /// <summary>
         /// Asynchronously send a request to a single handler without expecting a response
         /// </summary>
         /// <param name="request">Request object</param>
         /// <param name="cancellationToken">Optional cancellation token</param>
         /// <returns>A task that represents the send operation.</returns>
         Task Send(IRequest request, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Asynchronously send a request to a single handler without expecting a response
+        /// </summary>
+        /// <param name="requestType">Request type</param>
+        /// <param name="request">Request object</param>
+        /// <param name="cancellationToken">Optional cancellation token</param>
+        /// <returns>A task that represents the send operation.</returns>
+        Task Send(Type requestType, IRequest request, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Asynchronously send a notification to multiple handlers

--- a/test/MediatR.Tests/SendByTypeTests.cs
+++ b/test/MediatR.Tests/SendByTypeTests.cs
@@ -1,0 +1,59 @@
+using System.Threading;
+
+namespace MediatR.Tests
+{
+    using System.Threading.Tasks;
+    using Shouldly;
+    using StructureMap;
+    using Xunit;
+
+    public class SendByTypeTests
+    {
+        public interface IPing : IRequest<Pong>
+        {
+            string Message { get; set; }
+        }
+
+        public class Ping : IPing
+        {
+            public string Message { get; set; }
+        }
+
+        public class Pong
+        {
+            public string Message { get; set; }
+        }
+
+        public class PingHandler : IRequestHandler<IPing, Pong>
+        {
+            public Task<Pong> Handle(IPing request, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(new Pong { Message = request.Message + " Pong" });
+            }
+        }
+
+        [Fact]
+        public async Task Should_resolve_main_handler()
+        {
+            var container = new Container(cfg =>
+            {
+                cfg.Scan(scanner =>
+                {
+                    scanner.AssemblyContainingType(typeof(PublishTests));
+                    scanner.IncludeNamespaceContainingType<Ping>();
+                    scanner.WithDefaultConventions();
+                    scanner.AddAllTypesOf(typeof(IRequestHandler<,>));
+                });
+                cfg.For<SingleInstanceFactory>().Use<SingleInstanceFactory>(ctx => t => ctx.GetInstance(t));
+                cfg.For<MultiInstanceFactory>().Use<MultiInstanceFactory>(ctx => t => ctx.GetAllInstances(t));
+                cfg.For<IMediator>().Use<Mediator>();
+            });
+
+            var mediator = container.GetInstance<IMediator>();
+
+            var response = await mediator.Send<IPing, Pong>(new Ping { Message = "Ping" });
+
+            response.Message.ShouldBe("Ping Pong");
+        }
+    }
+}

--- a/test/MediatR.Tests/SendVoidInterfaceByTypeTests.cs
+++ b/test/MediatR.Tests/SendVoidInterfaceByTypeTests.cs
@@ -1,0 +1,70 @@
+using System.Threading;
+
+namespace MediatR.Tests
+{
+    using System;
+    using System.IO;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Shouldly;
+    using StructureMap;
+    using StructureMap.Graph;
+    using Xunit;
+
+    public class SendVoidInterfaceByTypeTests
+    {
+        public interface IPing : IRequest
+        {
+            string Message { get; set; }
+        }
+
+        public class Ping : IPing
+        {
+            public string Message { get; set; }
+        }
+
+        public class PingHandler : IRequestHandler<IPing>
+        {
+            private readonly TextWriter _writer;
+
+            public PingHandler(TextWriter writer)
+            {
+                _writer = writer;
+            }
+
+            public Task Handle(IPing message, CancellationToken cancellationToken)
+            {
+                return _writer.WriteAsync(message.Message + " Pong");
+            }
+        }
+
+        [Fact]
+        public async Task Should_resolve_main_void_handler()
+        {
+            var builder = new StringBuilder();
+            var writer = new StringWriter(builder);
+
+            var container = new Container(cfg =>
+            {
+                cfg.Scan(scanner =>
+                {
+                    scanner.AssemblyContainingType(typeof(PublishTests));
+                    scanner.IncludeNamespaceContainingType<Ping>();
+                    scanner.WithDefaultConventions();
+                    scanner.AddAllTypesOf(typeof(IRequestHandler<>));
+                });
+                cfg.For<SingleInstanceFactory>().Use<SingleInstanceFactory>(ctx => t => ctx.GetInstance(t));
+                cfg.For<MultiInstanceFactory>().Use<MultiInstanceFactory>(ctx => t => ctx.GetAllInstances(t));
+                cfg.For<TextWriter>().Use(writer);
+                cfg.For<IMediator>().Use<Mediator>();
+            });
+
+
+            var mediator = container.GetInstance<IMediator>();
+
+            await mediator.Send(new Ping { Message = "Ping" });
+
+            builder.ToString().ShouldBe("Ping Pong");
+        }
+    }
+}


### PR DESCRIPTION
I think it could be helpful to have these new overloads that I added to Mediator.Send, which it allows users to be more specific with the request type that they are sending. 

Since I have been trying to get a project to be as segregated as possible I didn't want to have handlers on my UI project and I do not want to lose the ability to use my ViewModels as MediatR requests, I was thinking that maybe we could segregate this by using interfaces (ICreateUser : IRequest) but since MediatR only uses request.GetType() to understand the type of request this is not possible. These new overloads could make that scenario possible. 