### PR TITLE
Using assembly in COM Interop Assemblies results in build error

### DIFF
--- a/src/MediatR/AssemblyInfo.cs
+++ b/src/MediatR/AssemblyInfo.cs
@@ -1,3 +1,5 @@
-﻿using System;
+using System;
+using System.Runtime.InteropServices;
 
 [assembly: CLSCompliant(true)]
+[assembly: ComVisible(false)]


### PR DESCRIPTION
if this attribute is not defined .net will determine that it should be true.

Using it in a COM Visible assembly with register for COM (i.e. COM-Addin for Office) results in a compiler exception that the assembly has to be registered using regasm even if nothing in it should be COM Visible