### PR TITLE
Setting up Constrained Notification Handler example for Simple Injector.

### DIFF
--- a/samples/MediatR.Examples.SimpleInjector/Program.cs
+++ b/samples/MediatR.Examples.SimpleInjector/Program.cs
@@ -27,7 +27,15 @@ namespace MediatR.Examples.SimpleInjector
             container.RegisterSingleton<IMediator, Mediator>();
             container.Register(typeof(IRequestHandler<,>), assemblies);
 			container.Register(typeof(IRequestHandler<>), assemblies);
-            container.RegisterCollection(typeof(INotificationHandler<>), assemblies);
+
+            // we have to do this because by default, generic type definitions (such as the Constrained Notification Handler) won't be registered
+            var notificationHandlerTypes = container.GetTypesToRegister(typeof(INotificationHandler<>), assemblies, new TypesToRegisterOptions
+            {
+                IncludeGenericTypeDefinitions = true,
+                IncludeComposites = false,
+            });
+            container.RegisterCollection(typeof(INotificationHandler<>), notificationHandlerTypes);
+
             container.RegisterSingleton<TextWriter>(writer);
 
             //Pipeline


### PR DESCRIPTION
I edited the example Simple Injector registrations to get a `Y` for `Constrained Notification Handler`.

This should be a recommended way to automatically register generic types in `RegisterCollection` as the same approach is mentioned in [Simple Injector documentation](https://simpleinjector.readthedocs.io/en/latest/advanced.html#mixing-collections-of-open-generic-and-non-generic-components)  (see last code snippet in the section).