### PR TITLE
change container.Register to container.Collection.Register

### DIFF
--- a/samples/MediatR.Examples.SimpleInjector/Program.cs
+++ b/samples/MediatR.Examples.SimpleInjector/Program.cs
@@ -38,14 +38,14 @@ namespace MediatR.Examples.SimpleInjector
             container.Register(() => (TextWriter)writer, Lifestyle.Singleton);
 
             //Pipeline
-            container.Register(typeof(IPipelineBehavior<,>), new []
+            container.Collection.Register(typeof(IPipelineBehavior<,>), new []
             {
                 typeof(RequestPreProcessorBehavior<,>),
                 typeof(RequestPostProcessorBehavior<,>),
                 typeof(GenericPipelineBehavior<,>)
             });
-            container.Register(typeof(IRequestPreProcessor<>), new [] { typeof(GenericRequestPreProcessor<>) });
-            container.Register(typeof(IRequestPostProcessor<,>), new[] { typeof(GenericRequestPostProcessor<,>), typeof(ConstrainedRequestPostProcessor<,>) });
+            container.Collection.Register(typeof(IRequestPreProcessor<>), new [] { typeof(GenericRequestPreProcessor<>) });
+            container.Collection.Register(typeof(IRequestPostProcessor<,>), new[] { typeof(GenericRequestPostProcessor<,>), typeof(ConstrainedRequestPostProcessor<,>) });
 
             container.Register(() => new ServiceFactory(container.GetInstance), Lifestyle.Singleton);
 


### PR DESCRIPTION
Updated for the Pipeline types. This fixes the SimpleInjector error:

The supplied list of types contains one or multiple open generic types, but this method is unable to handle open generic types because it can only map closed generic service types to a single implementation. You must register the open-generic types separately using the Register(Type, Type) overload. Alternatively, try using Container.Collection.Register instead, if you expect to have multiple implementations per closed-generic abstraction.