### PR TITLE
Register INotificationHandler as a collection

### DIFF
--- a/samples/MediatR.Examples.SimpleInjector/Program.cs
+++ b/samples/MediatR.Examples.SimpleInjector/Program.cs
@@ -33,7 +33,7 @@ namespace MediatR.Examples.SimpleInjector
                 IncludeGenericTypeDefinitions = true,
                 IncludeComposites = false,
             });
-            container.Register(typeof(INotificationHandler<>), notificationHandlerTypes);
+            container.Collection.Register(typeof(INotificationHandler<>), notificationHandlerTypes);
 
             container.Register(() => (TextWriter)writer, Lifestyle.Singleton);
 


### PR DESCRIPTION
After dotnet restore and dotnet run, simpleinjector throws an exception:  

> Unhandled Exception: System.ArgumentException: The supplied list of types contains one or multiple open generic types...  

By registering INotificationHandler as a collection the application performs as expected