### PR TITLE
Add PipelineExtensions for IRequest and INotification

### DIFF
--- a/src/MediatR/PipelineExtensions.cs
+++ b/src/MediatR/PipelineExtensions.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediatR
+{
+    public static class PipelineExtensions
+    {
+        public static Task<TResponse> Send<TResponse>(this IRequest<TResponse> request, IMediator mediator,
+            CancellationToken cancellationToken = default)
+            => mediator.Send(request, cancellationToken);
+
+        public static Task<TResponse> Send<TRequest, TResponse>(this TRequest request,
+            IRequestHandler<TRequest, TResponse> handler, CancellationToken cancellationToken = default)
+            where TRequest : IRequest<TResponse>
+            => handler.Handle(request, cancellationToken);
+
+        public static Task Publish(this INotification notification, IMediator mediator,
+            CancellationToken cancellationToken = default)
+            => mediator.Publish(notification, cancellationToken);
+
+        public static Task Publish<TNotification>(this TNotification notification,
+            INotificationHandler<TNotification> handler, CancellationToken cancellationToken = default)
+            where TNotification : INotification
+            => handler.Handle(notification, cancellationToken);
+    }
+}

--- a/test/MediatR.Tests/PublishTests.cs
+++ b/test/MediatR.Tests/PublishTests.cs
@@ -182,5 +182,52 @@ namespace MediatR.Tests
             result.ShouldContain("Ping Pong");
             result.ShouldContain("Ping Pung");
         }
+
+        [Fact]
+        public async Task Should_resolve_handlers_given_interface_with_mediator_extnesion()
+        {
+            var builder = new StringBuilder();
+            var writer = new StringWriter(builder);
+
+            var container = new Container(cfg =>
+            {
+                cfg.Scan(scanner =>
+                {
+                    scanner.AssemblyContainingType(typeof(PublishTests));
+                    scanner.IncludeNamespaceContainingType<Ping>();
+                    scanner.WithDefaultConventions();
+                    scanner.AddAllTypesOf(typeof(INotificationHandler<>));
+                });
+                cfg.For<TextWriter>().Use(writer);
+                cfg.For<IMediator>().Use<SequentialMediator>();
+                cfg.For<ServiceFactory>().Use<ServiceFactory>(ctx => t => ctx.GetInstance(t));
+            });
+
+            var mediator = container.GetInstance<IMediator>();
+
+            await
+                new Ping { Message = "Ping" }
+                    .Publish(mediator);
+
+            var result = builder.ToString().Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+            result.ShouldContain("Ping Pong");
+            result.ShouldContain("Ping Pung");
+        }
+
+        [Fact]
+        public async Task Should_resolve_handlers_given_interface_with_handler_extension()
+        {
+            var builder = new StringBuilder();
+            var writer = new StringWriter(builder);
+
+            var mediator = new PongHandler(writer);
+
+            await
+                new Ping { Message = "Ping" }
+                    .Publish(mediator);
+
+            var result = builder.ToString().Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+            result.ShouldContain("Ping Pong");
+        }
     }
 }

--- a/test/MediatR.Tests/PublishTests.cs
+++ b/test/MediatR.Tests/PublishTests.cs
@@ -184,7 +184,7 @@ namespace MediatR.Tests
         }
 
         [Fact]
-        public async Task Should_resolve_handlers_given_interface_with_mediator_extnesion()
+        public async Task Should_resolve_handlers_given_interface_with_mediator_extension()
         {
             var builder = new StringBuilder();
             var writer = new StringWriter(builder);

--- a/test/MediatR.Tests/SendTests.cs
+++ b/test/MediatR.Tests/SendTests.cs
@@ -50,5 +50,42 @@ namespace MediatR.Tests
 
             response.Message.ShouldBe("Ping Pong");
         }
+
+        [Fact]
+        public async Task Should_resolve_main_handler_with_mediator_extension()
+        {
+            var container = new Container(cfg =>
+            {
+                cfg.Scan(scanner =>
+                {
+                    scanner.AssemblyContainingType(typeof(PublishTests));
+                    scanner.IncludeNamespaceContainingType<Ping>();
+                    scanner.WithDefaultConventions();
+                    scanner.AddAllTypesOf(typeof(IRequestHandler<,>));
+                });
+                cfg.For<ServiceFactory>().Use<ServiceFactory>(ctx => t => ctx.GetInstance(t));
+                cfg.For<IMediator>().Use<Mediator>();
+            });
+
+            var mediator = container.GetInstance<IMediator>();
+
+            var response = await
+                new Ping { Message = "Ping" }
+                    .Send(mediator);
+
+            response.Message.ShouldBe("Ping Pong");
+        }
+
+        [Fact]
+        public async Task Should_resolve_main_handler_with_handler_extension()
+        {
+           var handler = new PingHandler();
+
+            var response = await
+                new Ping { Message = "Ping" }
+                    .Send(handler);
+
+            response.Message.ShouldBe("Ping Pong");
+        }
     }
 }


### PR DESCRIPTION
PipelineExtensions.cs allows a pipeline style of programming rather than nested style. (This is not related to PipelineBehaviors.) This style is possible with F#'s Pipe Forward operator. And, there is discussion in adding Pipe Forward operators to C# in [csharplang](https://github.com/dotnet/csharplang/issues?q=74+96).

Instead of nesting:
```
Mediator.Send(
    new Request()
    {
        Value = "value",
    },
    token);
```
PipelineExtension:
```
new Request()
    {
        Value = "value",
    }
    .Send(Mediator, token);
```
Pipe Forward (proposed CSharp feature):
```
new Request()
    {
        Value = "value",
    }
    |> Mediator(@, token);
```
The discussions have suggested using `@` or `<|` (what F# uses).

Unit Tests included.