### PR TITLE
Created unit tests for more complete coverage

### DIFF
--- a/test/MediatR.Tests/NotificationHandlerTests.cs
+++ b/test/MediatR.Tests/NotificationHandlerTests.cs
@@ -29,7 +29,7 @@ namespace MediatR.Tests
         }
 
         [Fact]
-        public async Task Should_call_abstract_handler()
+        public async Task Should_call_abstract_handle_method()
         {
             var builder = new StringBuilder();
             var writer = new StringWriter(builder);

--- a/test/MediatR.Tests/NotificationHandlerTests.cs
+++ b/test/MediatR.Tests/NotificationHandlerTests.cs
@@ -1,0 +1,48 @@
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace MediatR.Tests
+{
+    public class NotificationHandlerTests
+    {
+        public class Ping : INotification
+        {
+            public string Message { get; set; }
+        }
+
+        public class PongChildHandler : NotificationHandler<Ping>
+        {
+            private readonly TextWriter _writer;
+
+            public PongChildHandler(TextWriter writer)
+            {
+                _writer = writer;
+            }
+
+            protected override void Handle(Ping notification)
+            {
+                _writer.WriteLine(notification.Message + " Pong");
+            }
+        }
+
+        [Fact]
+        public async Task Should_call_abstract_handler()
+        {
+            var builder = new StringBuilder();
+            var writer = new StringWriter(builder);
+
+            INotificationHandler<Ping> handler = new PongChildHandler(writer);
+
+            await handler.Handle(
+                new Ping() { Message = "Ping" },
+                default
+            );
+
+            var result = builder.ToString();
+            result.ShouldContain("Ping Pong");
+        }
+    }
+}

--- a/test/MediatR.Tests/RequestHandlerTests.cs
+++ b/test/MediatR.Tests/RequestHandlerTests.cs
@@ -1,0 +1,37 @@
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace MediatR.Tests
+{
+    public class RequestHandlerTests
+    {
+        public class Ping : IRequest<Pong>
+        {
+            public string Message { get; set; }
+        }
+
+        public class Pong
+        {
+            public string Message { get; set; }
+        }
+
+        public class PingHandler : RequestHandler<Ping, Pong>
+        {
+            protected override Pong Handle(Ping request)
+            {
+                return new Pong { Message = request.Message + " Pong" };
+            }
+        }
+
+        [Fact]
+        public async Task Should_call_abstract_handler()
+        {
+            IRequestHandler<Ping, Pong> handler = new PingHandler();
+
+            var response = await handler.Handle(new Ping() { Message = "Ping" }, default);
+
+            response.Message.ShouldBe("Ping Pong");
+        }
+    }
+}

--- a/test/MediatR.Tests/RequestHandlerUnitTests.cs
+++ b/test/MediatR.Tests/RequestHandlerUnitTests.cs
@@ -1,0 +1,45 @@
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace MediatR.Tests
+{
+    public class RequestHandlerUnitTests
+    {
+        public class Ping : IRequest
+        {
+            public string Message { get; set; }
+        }
+
+        public class PingHandler : RequestHandler<Ping>
+        {
+            private readonly TextWriter _writer;
+
+            public PingHandler(TextWriter writer)
+            {
+                _writer = writer;
+            }
+
+            protected override void Handle(Ping request)
+            {
+                _writer.WriteLine(request.Message + " Pong");
+            }
+        }
+
+        [Fact]
+        public async Task Should_call_abstract_unit_handler()
+        {
+            var builder = new StringBuilder();
+            var writer = new StringWriter(builder);
+
+            IRequestHandler<Ping, Unit> handler = new PingHandler(writer);
+
+            await handler.Handle(new Ping() { Message = "Ping" }, default);
+
+            var result = builder.ToString();
+            result.ShouldContain("Ping Pong");
+        }
+    }
+}

--- a/test/MediatR.Tests/ServiceFactoryTests.cs
+++ b/test/MediatR.Tests/ServiceFactoryTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MediatR.Tests
+{
+    public class ServiceFactoryTests
+    {
+        public class Ping : IRequest<Pong>
+        {
+
+        }
+
+        public class Pong
+        {
+            public string Message { get; set; }
+        }
+
+        [Fact]
+        public async Task Should_throw_given_no_handler()
+        {
+            var serviceFactory = new ServiceFactory(type =>
+                typeof(IEnumerable).IsAssignableFrom(type)
+                    ? Array.CreateInstance(type.GetGenericArguments().First(), 0)
+                    : null);
+
+            var mediator = new Mediator(serviceFactory);
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => mediator.Send(new Ping())
+            );
+
+            Assert.StartsWith("Handler was not found for request", exception.Message);
+        }
+    }
+}

--- a/test/MediatR.Tests/UnitTests.cs
+++ b/test/MediatR.Tests/UnitTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MediatR.Tests
+{
+    public class UnitTests
+    {
+        [Fact]
+        public async Task Should_be_equal_to_each_other()
+        {
+            var unit1 = Unit.Value;
+            var unit2 = await Unit.Task;
+
+            Assert.Equal(unit1, unit2);
+            Assert.True(unit1 == unit2);
+            Assert.False(unit1 != unit2);
+        }
+
+        [Fact]
+        public void Should_be_equitable()
+        {
+            var dictionary = new Dictionary<Unit, string>
+            {
+                {new Unit(), "value"},
+            };
+
+            Assert.Equal("value", dictionary[default]);
+        }
+
+        [Fact]
+        public void Should_tostring()
+        {
+            var unit = Unit.Value;
+            Assert.Equal("()", unit.ToString());
+        }
+
+        [Fact]
+        public void Should_compareto_as_zero()
+        {
+            var unit1 = new Unit();
+            var unit2 = new Unit();
+
+            Assert.Equal(0, unit1.CompareTo(unit2));
+        }
+
+        public static object[][] ValueData()
+        {
+            return new[]
+            {
+                new object[] {new object(), false},
+                new object[] {"", false},
+                new object[] {"()", false},
+                new object[] {null, false},
+                new object[] {new Uri("https://www.google.com"), false},
+                new object[] {new Unit(), true},
+                new object[] {Unit.Value, true},
+                new object[] {Unit.Task.Result, true},
+                new object[] {default(Unit), true},
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(ValueData))]
+        public void Should_be_equal(object value, bool isEqual)
+        {
+            var unit1 = Unit.Value;
+
+            if (isEqual)
+                Assert.True(unit1.Equals(value));
+            else
+                Assert.False(unit1.Equals(value));
+        }
+
+        [Theory]
+        [MemberData(nameof(ValueData))]
+        public void Should_compareto_value_as_zero(object value, bool _)
+        {
+            var unit1 = new Unit();
+
+            Assert.Equal(0, ((IComparable)unit1).CompareTo(value));
+        }
+    }
+}


### PR DESCRIPTION
Increase Unit Test Coverage to 100% (for MediatR, not MediatoR.Tests).

Notes on some unit tests:

`UnitTests.Should_be_equal`
Asserts that all MediatR.Unit objects have `.Equals()` of true, but false for non-Unit objects and null.
`UnitTests.Should_compareto_object_as_zero`
Asserts that MediatR.Unit objects .CompareTo() as 0 to all objects, even null or other types.

Maybe the implementation of .CompareTo() should only return 0 for Unit objects and null, and either -1 or 1 for non Unit objects. 0 for null because this object only exists because System.Void is not a usable type in C#. Also, maybe Unit should be `.Equals()` of true for null.