### PR TITLE
Change PublishCore to take a Func<Task>, so implementors have more fi…

### DIFF
--- a/src/MediatR/Internal/NotificationHandlerWrapper.cs
+++ b/src/MediatR/Internal/NotificationHandlerWrapper.cs
@@ -8,17 +8,17 @@ namespace MediatR.Internal
 
     internal abstract class NotificationHandlerWrapper
     {
-        public abstract Task Handle(INotification notification, CancellationToken cancellationToken, ServiceFactory serviceFactory, Func<IEnumerable<Task>, Task> publish);
+        public abstract Task Handle(INotification notification, CancellationToken cancellationToken, ServiceFactory serviceFactory, Func<IEnumerable<Func<Task>>, Task> publish);
     }
 
     internal class NotificationHandlerWrapperImpl<TNotification> : NotificationHandlerWrapper
         where TNotification : INotification
     {
-        public override Task Handle(INotification notification, CancellationToken cancellationToken, ServiceFactory serviceFactory, Func<IEnumerable<Task>, Task> publish)
+        public override Task Handle(INotification notification, CancellationToken cancellationToken, ServiceFactory serviceFactory, Func<IEnumerable<Func<Task>>, Task> publish)
         {
             var handlers = serviceFactory
                 .GetInstances<INotificationHandler<TNotification>>()
-                .Select(x => x.Handle((TNotification)notification, cancellationToken));
+                .Select(x => new Func<Task>(() => x.Handle((TNotification)notification, cancellationToken)));
 
             return publish(handlers);
         }

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -70,11 +70,11 @@ namespace MediatR
         /// </summary>
         /// <param name="allHandlers">Enumerable of tasks representing invoking each notification handler</param>
         /// <returns>A task representing invoking all handlers</returns>
-        protected virtual async Task PublishCore(IEnumerable<Task> allHandlers)
+        protected virtual async Task PublishCore(IEnumerable<Func<Task>> allHandlers)
         {
             foreach (var handler in allHandlers)
             {
-                await handler.ConfigureAwait(false);
+                await handler().ConfigureAwait(false);
             }
         }
 

--- a/test/MediatR.Tests/PublishTests.cs
+++ b/test/MediatR.Tests/PublishTests.cs
@@ -115,11 +115,11 @@ namespace MediatR.Tests
             {
             }
 
-            protected override async Task PublishCore(IEnumerable<Task> allHandlers)
+            protected override async Task PublishCore(IEnumerable<Func<Task>> allHandlers)
             {
                 foreach (var handler in allHandlers)
                 {
-                    await handler;
+                    await handler().ConfigureAwait(false);
                 }
             }
         }


### PR DESCRIPTION
Change PublishCore to take a Func<Task>, so implementors have more fine-grained control over when a handler is executed

See #328

This came out of that thread. But thinking about this a bit more, this would also open up the possibility for Task.Run(() => handler()) or something more sophisticated.

