### PR TITLE
Example strategies for publishing notifications

### DIFF
--- a/MediatR.sln
+++ b/MediatR.sln
@@ -45,6 +45,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MediatR.Examples.DryIocZero
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MediatR.Examples.Lamar", "samples\MediatR.Examples.Lamar\MediatR.Examples.Lamar.csproj", "{F014598D-8B85-4D7E-942A-3493107ABE43}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediatR.Examples.PublishStrategies", "samples\MediatR.Examples.PublishStrategies\MediatR.Examples.PublishStrategies.csproj", "{867EBA13-62F4-4525-8F92-B0AD828EE6D4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -107,6 +109,10 @@ Global
 		{F014598D-8B85-4D7E-942A-3493107ABE43}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F014598D-8B85-4D7E-942A-3493107ABE43}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F014598D-8B85-4D7E-942A-3493107ABE43}.Release|Any CPU.Build.0 = Release|Any CPU
+		{867EBA13-62F4-4525-8F92-B0AD828EE6D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{867EBA13-62F4-4525-8F92-B0AD828EE6D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{867EBA13-62F4-4525-8F92-B0AD828EE6D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{867EBA13-62F4-4525-8F92-B0AD828EE6D4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -126,6 +132,7 @@ Global
 		{E6C51E44-59B4-4F4F-AFB3-4032CDDEF07A} = {95CFF0CD-87A6-4CB6-A99F-42EAD0829E37}
 		{49AC9726-ECDF-45C0-B5B8-B4AB7F0E6B46} = {95CFF0CD-87A6-4CB6-A99F-42EAD0829E37}
 		{F014598D-8B85-4D7E-942A-3493107ABE43} = {95CFF0CD-87A6-4CB6-A99F-42EAD0829E37}
+		{867EBA13-62F4-4525-8F92-B0AD828EE6D4} = {95CFF0CD-87A6-4CB6-A99F-42EAD0829E37}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D58286E3-878B-4ACB-8E76-F61E708D4339}

--- a/samples/MediatR.Examples.PublishStrategies/AsyncPingedHandler.cs
+++ b/samples/MediatR.Examples.PublishStrategies/AsyncPingedHandler.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediatR.Examples.PublishStrategies
+{
+    public class AsyncPingedHandler : INotificationHandler<Pinged>
+    {
+        public AsyncPingedHandler(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; set; }
+
+        public async Task Handle(Pinged notification, CancellationToken cancellationToken)
+        {
+            if (Name == "2")
+            {
+                throw new ArgumentException("Name cannot be '2'");
+            }
+
+            Console.WriteLine($"[AsyncPingedHandler {Name}] {DateTime.Now:HH:mm:ss.fff} : Pinged");
+            await Task.Delay(100).ConfigureAwait(false);
+            Console.WriteLine($"[AsyncPingedHandler {Name}] {DateTime.Now:HH:mm:ss.fff} : After pinged");
+        }
+    }
+}

--- a/samples/MediatR.Examples.PublishStrategies/CustomMediator.cs
+++ b/samples/MediatR.Examples.PublishStrategies/CustomMediator.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace MediatR.Examples.PublishStrategies
+{
+    public class CustomMediator : Mediator
+    {
+        private Func<IEnumerable<Func<Task>>, Task> _publish;
+
+        public CustomMediator(ServiceFactory serviceFactory, Func<IEnumerable<Func<Task>>, Task> publish) : base(serviceFactory)
+        {
+            _publish = publish;
+        }
+
+        protected override Task PublishCore(IEnumerable<Func<Task>> allHandlers)
+        {
+            return _publish(allHandlers);
+        }
+    }
+}

--- a/samples/MediatR.Examples.PublishStrategies/MediatR.Examples.PublishStrategies.csproj
+++ b/samples/MediatR.Examples.PublishStrategies/MediatR.Examples.PublishStrategies.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MediatR\MediatR.csproj" />
+    <ProjectReference Include="..\MediatR.Examples\MediatR.Examples.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/MediatR.Examples.PublishStrategies/Program.cs
+++ b/samples/MediatR.Examples.PublishStrategies/Program.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MediatR.Examples.PublishStrategies
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            var services = new ServiceCollection();
+            services.AddScoped<ServiceFactory>(p => p.GetService);
+
+            services.AddSingleton<Publisher>();
+
+            services.AddTransient<INotificationHandler<Pinged>>(sp => new SyncPingedHandler("1"));
+            services.AddTransient<INotificationHandler<Pinged>>(sp => new AsyncPingedHandler("2"));
+            services.AddTransient<INotificationHandler<Pinged>>(sp => new AsyncPingedHandler("3"));
+            services.AddTransient<INotificationHandler<Pinged>>(sp => new SyncPingedHandler("4"));
+
+            var provider = services.BuildServiceProvider();
+
+            var publisher = provider.GetRequiredService<Publisher>();
+
+            var pinged = new Pinged();
+
+            foreach (PublishStrategy strategy in Enum.GetValues(typeof(PublishStrategy)))
+            {
+                Console.WriteLine($"Strategy: {strategy}");
+                Console.WriteLine("----------");
+
+                try
+                {
+                    await publisher.Publish(pinged, strategy);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"{ex.GetType()}: {ex.Message}");
+                }
+
+                await Task.Delay(1000);
+                Console.WriteLine("----------");
+            }
+
+            Console.WriteLine("done");
+        }
+    }
+}

--- a/samples/MediatR.Examples.PublishStrategies/PublishStrategy.cs
+++ b/samples/MediatR.Examples.PublishStrategies/PublishStrategy.cs
@@ -1,0 +1,38 @@
+namespace MediatR.Examples.PublishStrategies
+{
+    /// <summary>
+    /// Strategy to use when publishing notifications
+    /// </summary>
+    public enum PublishStrategy
+    {
+        /// <summary>
+        /// Run each notification handler after one another. Returns when all handlers are finished. In case of any exception(s), they will be captured in an AggregateException.
+        /// </summary>
+        SyncContinueOnException = 0,
+
+        /// <summary>
+        /// Run each notification handler after one another. Returns when all handlers are finished or an exception has been thrown. In case of an exception, any handlers after that will not be run.
+        /// </summary>
+        SyncStopOnException = 1,
+
+        /// <summary>
+        /// Run all notification handlers asynchronously. Returns when all handlers are finished. In case of any exception(s), they will be captured in an AggregateException.
+        /// </summary>
+        Async = 2,
+
+        /// <summary>
+        /// Run each notification handler on it's own thread using Task.Run(). Returns immediately and does not wait for any handlers to finish. Note that you cannot capture any exceptions, even if you await the call to Publish.
+        /// </summary>
+        ParallelNoWait = 3,
+
+        /// <summary>
+        /// Run each notification handler on it's own thread using Task.Run(). Returns when all threads (handlers) are finished. In case of any exception(s), they are captured in an AggregateException by Task.WhenAll.
+        /// </summary>
+        ParallelWhenAll = 4,
+
+        /// <summary>
+        /// Run each notification handler on it's own thread using Task.Run(). Returns when any thread (handler) is finished. Note that you cannot capture any exceptions (See msdn documentation of Task.WhenAny)
+        /// </summary>
+        ParallelWhenAny = 5,
+    }
+}

--- a/samples/MediatR.Examples.PublishStrategies/Publisher.cs
+++ b/samples/MediatR.Examples.PublishStrategies/Publisher.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediatR.Examples.PublishStrategies
+{
+    public class Publisher
+    {
+        private readonly ServiceFactory _serviceFactory;
+
+        public Publisher(ServiceFactory serviceFactory)
+        {
+            _serviceFactory = serviceFactory;
+
+            PublishStrategies[PublishStrategy.Async] = new CustomMediator(_serviceFactory, AsyncContinueOnException);
+            PublishStrategies[PublishStrategy.ParallelNoWait] = new CustomMediator(_serviceFactory, ParallelNoWait);
+            PublishStrategies[PublishStrategy.ParallelWhenAll] = new CustomMediator(_serviceFactory, ParallelWhenAll);
+            PublishStrategies[PublishStrategy.ParallelWhenAny] = new CustomMediator(_serviceFactory, ParallelWhenAny);
+            PublishStrategies[PublishStrategy.SyncContinueOnException] = new CustomMediator(_serviceFactory, SyncContinueOnException);
+            PublishStrategies[PublishStrategy.SyncStopOnException] = new CustomMediator(_serviceFactory, SyncStopOnException);
+        }
+
+        public IDictionary<PublishStrategy, IMediator> PublishStrategies = new Dictionary<PublishStrategy, IMediator>();
+        public PublishStrategy DefaultStrategy { get; set; } = PublishStrategy.SyncContinueOnException;
+
+        public Task Publish<TNotification>(TNotification notification)
+        {
+            return Publish(notification, DefaultStrategy, default(CancellationToken));
+        }
+
+        public Task Publish<TNotification>(TNotification notification, PublishStrategy strategy)
+        {
+            return Publish(notification, strategy, default(CancellationToken));
+        }
+
+        public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken)
+        {
+            return Publish(notification, DefaultStrategy, cancellationToken);
+        }
+
+        public Task Publish<TNotification>(TNotification notification, PublishStrategy strategy, CancellationToken cancellationToken)
+        {
+            if (!PublishStrategies.TryGetValue(strategy, out var mediator))
+            {
+                throw new ArgumentException($"Unknown strategy: {strategy}");
+            }
+
+            return mediator.Publish(notification, cancellationToken);
+        }
+
+        private Task ParallelWhenAll(IEnumerable<Func<Task>> handlers)
+        {
+            var tasks = new List<Task>();
+
+            foreach (var handler in handlers)
+            {
+                tasks.Add(Task.Run(() => handler()));
+            }
+
+            return Task.WhenAll(tasks);
+        }
+
+        private Task ParallelWhenAny(IEnumerable<Func<Task>> handlers)
+        {
+            var tasks = new List<Task>();
+
+            foreach (var handler in handlers)
+            {
+                tasks.Add(Task.Run(() => handler()));
+            }
+
+            return Task.WhenAny(tasks);
+        }
+
+        private Task ParallelNoWait(IEnumerable<Func<Task>> handlers)
+        {
+            foreach (var handler in handlers)
+            {
+                Task.Run(() => handler());
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private async Task AsyncContinueOnException(IEnumerable<Func<Task>> handlers)
+        {
+            var tasks = new List<Task>();
+            var exceptions = new List<Exception>();
+
+            foreach (var handler in handlers)
+            {
+                try
+                {
+                    tasks.Add(handler());
+                }
+                catch (AggregateException ex)
+                {
+                    exceptions.AddRange(ex.InnerExceptions);
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            }
+
+            try
+            {
+                await Task.WhenAll(tasks);
+            }
+            catch (AggregateException ex)
+            {
+                exceptions.AddRange(ex.InnerExceptions);
+            }
+            catch (Exception ex)
+            {
+                exceptions.Add(ex);
+            }
+
+            if (exceptions.Any())
+            {
+                throw new AggregateException(exceptions);
+            }
+        }
+
+        private async Task SyncStopOnException(IEnumerable<Func<Task>> handlers)
+        {
+            foreach (var handler in handlers)
+            {
+                await handler().ConfigureAwait(false);
+            }
+        }
+
+        private async Task SyncContinueOnException(IEnumerable<Func<Task>> handlers)
+        {
+            var exceptions = new List<Exception>();
+
+            foreach (var handler in handlers)
+            {
+                try
+                {
+                    await handler();
+                }
+                catch (AggregateException ex)
+                {
+                    exceptions.AddRange(ex.InnerExceptions);
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            }
+
+            if (exceptions.Any())
+            {
+                throw new AggregateException(exceptions);
+            }
+        }
+    }
+}

--- a/samples/MediatR.Examples.PublishStrategies/Publisher.cs
+++ b/samples/MediatR.Examples.PublishStrategies/Publisher.cs
@@ -95,11 +95,7 @@ namespace MediatR.Examples.PublishStrategies
                 {
                     tasks.Add(handler());
                 }
-                catch (AggregateException ex)
-                {
-                    exceptions.AddRange(ex.InnerExceptions);
-                }
-                catch (Exception ex)
+                catch (Exception ex) when (!(ex is OutOfMemoryException || ex is StackOverflowException))
                 {
                     exceptions.Add(ex);
                 }
@@ -107,13 +103,13 @@ namespace MediatR.Examples.PublishStrategies
 
             try
             {
-                await Task.WhenAll(tasks);
+                await Task.WhenAll(tasks).ConfigureAwait(false);
             }
             catch (AggregateException ex)
             {
-                exceptions.AddRange(ex.InnerExceptions);
+                exceptions.AddRange(ex.Flatten().InnerExceptions);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!(ex is OutOfMemoryException || ex is StackOverflowException))
             {
                 exceptions.Add(ex);
             }
@@ -140,13 +136,13 @@ namespace MediatR.Examples.PublishStrategies
             {
                 try
                 {
-                    await handler();
+                    await handler().ConfigureAwait(false);
                 }
                 catch (AggregateException ex)
                 {
-                    exceptions.AddRange(ex.InnerExceptions);
+                    exceptions.AddRange(ex.Flatten().InnerExceptions);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (!(ex is OutOfMemoryException || ex is StackOverflowException))
                 {
                     exceptions.Add(ex);
                 }

--- a/samples/MediatR.Examples.PublishStrategies/SyncPingedHandler.cs
+++ b/samples/MediatR.Examples.PublishStrategies/SyncPingedHandler.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediatR.Examples.PublishStrategies
+{
+    public class SyncPingedHandler : INotificationHandler<Pinged>
+    {
+        public SyncPingedHandler(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; set; }
+
+        public Task Handle(Pinged notification, CancellationToken cancellationToken)
+        {
+            if (Name == "2")
+            {
+                throw new ArgumentException("Name cannot be '2'");
+            }
+
+            Console.WriteLine($"[SyncPingedHandler {Name}] {DateTime.Now:HH:mm:ss.fff} : Pinged");
+            Thread.Sleep(100);
+            Console.WriteLine($"[SyncPingedHandler {Name}] {DateTime.Now:HH:mm:ss.fff} : After pinged");
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
This adds some examples of how to deal with different ways of publishing notifications and exception handling.

It's not perfect (the exception handling), but it shows the difference. The PublishStrategy enum has descriptions on them.

