### PR TITLE
Added sample project to show the ability of wrapping MediatR to help remove direct dependencies on IRequest etc

### DIFF
--- a/MediatR.sln
+++ b/MediatR.sln
@@ -45,7 +45,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MediatR.Examples.DryIocZero
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MediatR.Examples.Lamar", "samples\MediatR.Examples.Lamar\MediatR.Examples.Lamar.csproj", "{F014598D-8B85-4D7E-942A-3493107ABE43}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediatR.Examples.PublishStrategies", "samples\MediatR.Examples.PublishStrategies\MediatR.Examples.PublishStrategies.csproj", "{867EBA13-62F4-4525-8F92-B0AD828EE6D4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MediatR.Examples.PublishStrategies", "samples\MediatR.Examples.PublishStrategies\MediatR.Examples.PublishStrategies.csproj", "{867EBA13-62F4-4525-8F92-B0AD828EE6D4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MediatR.Examples.Wrapper", "samples\MediatR.Examples.Wrapper\MediatR.Examples.Wrapper.csproj", "{3BE149D3-656F-47A7-ACC7-6ECFBCB5F538}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -113,6 +115,10 @@ Global
 		{867EBA13-62F4-4525-8F92-B0AD828EE6D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{867EBA13-62F4-4525-8F92-B0AD828EE6D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{867EBA13-62F4-4525-8F92-B0AD828EE6D4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3BE149D3-656F-47A7-ACC7-6ECFBCB5F538}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3BE149D3-656F-47A7-ACC7-6ECFBCB5F538}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3BE149D3-656F-47A7-ACC7-6ECFBCB5F538}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3BE149D3-656F-47A7-ACC7-6ECFBCB5F538}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -133,6 +139,7 @@ Global
 		{49AC9726-ECDF-45C0-B5B8-B4AB7F0E6B46} = {95CFF0CD-87A6-4CB6-A99F-42EAD0829E37}
 		{F014598D-8B85-4D7E-942A-3493107ABE43} = {95CFF0CD-87A6-4CB6-A99F-42EAD0829E37}
 		{867EBA13-62F4-4525-8F92-B0AD828EE6D4} = {95CFF0CD-87A6-4CB6-A99F-42EAD0829E37}
+		{3BE149D3-656F-47A7-ACC7-6ECFBCB5F538} = {95CFF0CD-87A6-4CB6-A99F-42EAD0829E37}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D58286E3-878B-4ACB-8E76-F61E708D4339}

--- a/samples/MediatR.Examples.Wrapper/Commands/JingCommand.cs
+++ b/samples/MediatR.Examples.Wrapper/Commands/JingCommand.cs
@@ -1,0 +1,10 @@
+using MediatR.Examples.Wrapper.Core;
+
+namespace MediatR.Examples.Wrapper.Commands
+{
+    //Custom ICommand interface to allow you to remove direct MediatR refs
+    public class JingCommand : ICommand
+    {
+        public string Message { get; set; }
+    }
+}

--- a/samples/MediatR.Examples.Wrapper/Commands/JingCommandHandler.cs
+++ b/samples/MediatR.Examples.Wrapper/Commands/JingCommandHandler.cs
@@ -1,0 +1,22 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR.Examples.Wrapper.Core;
+
+namespace MediatR.Examples.Wrapper.Commands
+{
+    public class JingCommandHandler : CommandHandler<JingCommand>
+    {
+        private readonly TextWriter _writer;
+
+        public JingCommandHandler(TextWriter writer)
+        {
+            _writer = writer;
+        }
+
+        public override Task Handle(JingCommand command, CancellationToken cancellationToken)
+        {
+            return _writer.WriteLineAsync($"--- Handled JingCommand: {command.Message}, no Jong");
+        }
+    }
+}

--- a/samples/MediatR.Examples.Wrapper/Core/CommandHandler.cs
+++ b/samples/MediatR.Examples.Wrapper/Core/CommandHandler.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediatR.Examples.Wrapper.Core
+{
+    public abstract class CommandHandler<TCommand> : AsyncRequestHandler<CommandWrapper<TCommand>>
+        where TCommand : ICommand
+    {
+        public abstract Task Handle(TCommand command, CancellationToken cancellationToken);
+
+        protected override Task Handle(CommandWrapper<TCommand> request, CancellationToken cancellationToken)
+        {
+            return Handle(request.Command, cancellationToken);
+        }
+    }
+}

--- a/samples/MediatR.Examples.Wrapper/Core/CommandWrapper.cs
+++ b/samples/MediatR.Examples.Wrapper/Core/CommandWrapper.cs
@@ -1,0 +1,8 @@
+namespace MediatR.Examples.Wrapper.Core
+{
+    public class CommandWrapper<TCommand> : IRequest
+        where TCommand : ICommand
+    {
+        public TCommand Command { get; set; }
+    }
+}

--- a/samples/MediatR.Examples.Wrapper/Core/ICommand.cs
+++ b/samples/MediatR.Examples.Wrapper/Core/ICommand.cs
@@ -1,0 +1,6 @@
+namespace MediatR.Examples.Wrapper.Core
+{
+    public interface ICommand
+    {
+    }
+}

--- a/samples/MediatR.Examples.Wrapper/Core/ICommandMediator.cs
+++ b/samples/MediatR.Examples.Wrapper/Core/ICommandMediator.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediatR.Examples.Wrapper.Core
+{
+    public interface ICommandMediator
+    {
+        Task Handle<TCommand>(TCommand command, CancellationToken cancellationToken = default(CancellationToken))
+            where TCommand : ICommand;
+    }
+}

--- a/samples/MediatR.Examples.Wrapper/Core/IMediate.cs
+++ b/samples/MediatR.Examples.Wrapper/Core/IMediate.cs
@@ -1,0 +1,6 @@
+namespace MediatR.Examples.Wrapper.Core
+{
+    public interface IMediate : ICommandMediator, IQueryMediator
+    {
+    }
+}

--- a/samples/MediatR.Examples.Wrapper/Core/IQuery.cs
+++ b/samples/MediatR.Examples.Wrapper/Core/IQuery.cs
@@ -1,0 +1,6 @@
+namespace MediatR.Examples.Wrapper.Core
+{
+    public interface IQuery<TResponse>
+    {
+    }
+}

--- a/samples/MediatR.Examples.Wrapper/Core/IQueryMediator.cs
+++ b/samples/MediatR.Examples.Wrapper/Core/IQueryMediator.cs
@@ -1,0 +1,12 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediatR.Examples.Wrapper.Core
+{
+    public interface IQueryMediator
+    {
+        Task<TResponse> Handle<TQuery, TResponse>(TQuery query,
+            CancellationToken cancellationToken = default(CancellationToken))
+            where TQuery : IQuery<TResponse>;
+    }
+}

--- a/samples/MediatR.Examples.Wrapper/Core/Mediate.cs
+++ b/samples/MediatR.Examples.Wrapper/Core/Mediate.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediatR.Examples.Wrapper.Core
+{
+    public class Mediate : IMediate
+    {
+        private readonly IMediator mediator;
+
+        public Mediate(IMediator mediator)
+        {
+            this.mediator = mediator;
+        }
+
+        public Task Handle<TCommand>(TCommand command, CancellationToken cancellationToken = default(CancellationToken))
+            where TCommand : ICommand
+        {
+            return mediator.Send(new CommandWrapper<TCommand> { Command = command }, cancellationToken);
+        }
+
+        public Task<TResponse> Handle<TQuery, TResponse>(TQuery query, CancellationToken cancellationToken = default(CancellationToken))
+            where TQuery : IQuery<TResponse>
+        {
+            return mediator.Send(new QueryWrapper<TQuery, TResponse> { Query = query }, cancellationToken);
+        }
+    }
+}

--- a/samples/MediatR.Examples.Wrapper/Core/QueryHandler.cs
+++ b/samples/MediatR.Examples.Wrapper/Core/QueryHandler.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediatR.Examples.Wrapper.Core
+{
+    public abstract class QueryHandler<TQuery, TResponse> : IRequestHandler<QueryWrapper<TQuery, TResponse>, TResponse>
+        where TQuery : IQuery<TResponse>
+    {
+        public abstract Task<TResponse> Handle(TQuery query, CancellationToken cancellationToken);
+
+        public Task<TResponse> Handle(QueryWrapper<TQuery, TResponse> request, CancellationToken cancellationToken)
+        {
+            return Handle(request.Query, cancellationToken);
+        }
+    }
+}

--- a/samples/MediatR.Examples.Wrapper/Core/QueryWrapper.cs
+++ b/samples/MediatR.Examples.Wrapper/Core/QueryWrapper.cs
@@ -1,0 +1,8 @@
+namespace MediatR.Examples.Wrapper.Core
+{
+    public class QueryWrapper<TQuery, TResponse> : IRequest<TResponse>
+        where TQuery : IQuery<TResponse>
+    {
+        public TQuery Query { get; set; }
+    }
+}

--- a/samples/MediatR.Examples.Wrapper/MediatR.Examples.Wrapper.csproj
+++ b/samples/MediatR.Examples.Wrapper/MediatR.Examples.Wrapper.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Scrutor" Version="3.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MediatR.Examples\MediatR.Examples.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/MediatR.Examples.Wrapper/Program.cs
+++ b/samples/MediatR.Examples.Wrapper/Program.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using MediatR.Examples.Wrapper.Commands;
+using MediatR.Examples.Wrapper.Core;
+using MediatR.Examples.Wrapper.Queries;
+using MediatR.Pipeline;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MediatR.Examples.Wrapper
+{
+    public static class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            var writer = new WrappingWriter(Console.Out);
+            var mediator = BuildMediator(writer);
+
+            await mediator.Handle(new JingCommand {Message = "Hello world"});
+
+            var response = await mediator.Handle<PingQuery, PongResponse>(new PingQuery {Message = "Hello world"});
+
+            await writer.WriteLineAsync($"--- Handled PingQuery with response: {response.Message}");
+        }
+
+        private static IMediate BuildMediator(WrappingWriter writer)
+        {
+            var services = new ServiceCollection();
+
+            //Register wrappers
+            services.AddTransient<IMediate, Mediate>();
+            services.AddTransient<ICommandMediator, Mediate>();
+            services.AddTransient<IQueryMediator, Mediate>();
+
+            services.AddScoped<ServiceFactory>(p => p.GetService);
+
+            services.AddSingleton<TextWriter>(writer);
+
+            //Pipeline
+            services.AddScoped(typeof(IPipelineBehavior<,>), typeof(RequestPreProcessorBehavior<,>));
+            services.AddScoped(typeof(IPipelineBehavior<,>), typeof(RequestPostProcessorBehavior<,>));
+
+            //This causes a type load exception. https://github.com/jbogard/MediatR.Extensions.Microsoft.DependencyInjection/issues/12
+            //services.AddScoped(typeof(IRequestPostProcessor<,>), typeof(ConstrainedRequestPostProcessor<,>));
+            //services.AddScoped(typeof(INotificationHandler<>), typeof(ConstrainedPingedHandler<>));
+
+            // Use Scrutor to scan and register all
+            // classes as their implemented interfaces.
+            services.Scan(scan => scan
+                .FromAssembliesOf(typeof(IMediator), typeof(IMediate))
+                .AddClasses()
+                .AsImplementedInterfaces());
+
+            var provider = services.BuildServiceProvider();
+
+            return provider.GetRequiredService<IMediate>();
+        }
+    }
+}

--- a/samples/MediatR.Examples.Wrapper/Queries/PingQuery.cs
+++ b/samples/MediatR.Examples.Wrapper/Queries/PingQuery.cs
@@ -1,0 +1,10 @@
+using MediatR.Examples.Wrapper.Core;
+
+namespace MediatR.Examples.Wrapper.Queries
+{
+    //Custom IQuery<TResponse> interface to allow you to remove direct MediatR refs
+    public class PingQuery : IQuery<PongResponse>
+    {
+        public string Message { get; set; }
+    }
+}

--- a/samples/MediatR.Examples.Wrapper/Queries/PingQueryHandler.cs
+++ b/samples/MediatR.Examples.Wrapper/Queries/PingQueryHandler.cs
@@ -1,0 +1,23 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR.Examples.Wrapper.Core;
+
+namespace MediatR.Examples.Wrapper.Queries
+{
+    public class PingQueryHandler : QueryHandler<PingQuery, PongResponse>
+    {
+        private readonly TextWriter _writer;
+
+        public PingQueryHandler(TextWriter writer)
+        {
+            _writer = writer;
+        }
+
+        public override async Task<PongResponse> Handle(PingQuery query, CancellationToken cancellationToken)
+        {
+            await _writer.WriteLineAsync($"--- Handled PingQuery: {query.Message}");
+            return new PongResponse {Message = query.Message + " PongResponse" };
+        }
+    }
+}

--- a/samples/MediatR.Examples.Wrapper/Queries/PongResponse.cs
+++ b/samples/MediatR.Examples.Wrapper/Queries/PongResponse.cs
@@ -1,0 +1,7 @@
+namespace MediatR.Examples.Wrapper.Queries
+{
+    public class PongResponse
+    {
+        public string Message { get; set; }
+    }
+}


### PR DESCRIPTION
WHAT: A sample project showing off the ability to wrap MediatR to allow you to remove direct dependencies. 

WHY: I have Domain libraries which contain Commands and I would prefer to keep these libraries pure without external dependencies. Essentially I would not like to have references to IRequest, INotification etc within my Domain but prefer to be able to define my own interfaces.

SOLUTION: Define custom interfaces in my base Domain library along with things like Aggregate<>, ValueObject etc and use these to mark my Commands/ Queries and have things wire up based off these. 

I do think that this would be quite a common use case so think it would be beneficial to have some example code available to help people get up and running more quickly.

Thanks.