### PR TITLE
Add CancellationToken to IRequestPostProcessor

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <Authors>Jimmy Bogard</Authors>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>6.1.0</VersionPrefix>
+    <VersionPrefix>7.0.0</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/samples/MediatR.Examples/ConstrainedRequestPostProcessor.cs
+++ b/samples/MediatR.Examples/ConstrainedRequestPostProcessor.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using MediatR.Pipeline;
 
@@ -15,7 +16,7 @@ namespace MediatR.Examples
             _writer = writer;
         }
 
-        public Task Process(TRequest request, TResponse response)
+        public Task Process(TRequest request, TResponse response, CancellationToken cancellationToken)
         {
             return _writer.WriteLineAsync("- All Done with Ping");
         }

--- a/samples/MediatR.Examples/GenericRequestPostProcessor.cs
+++ b/samples/MediatR.Examples/GenericRequestPostProcessor.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using MediatR.Pipeline;
 
@@ -13,7 +14,7 @@ namespace MediatR.Examples
             _writer = writer;
         }
 
-        public Task Process(TRequest request, TResponse response)
+        public Task Process(TRequest request, TResponse response, CancellationToken cancellationToken)
         {
             return _writer.WriteLineAsync("- All Done");
         }

--- a/src/MediatR/Pipeline/IRequestPostProcessor.cs
+++ b/src/MediatR/Pipeline/IRequestPostProcessor.cs
@@ -1,5 +1,6 @@
-﻿namespace MediatR.Pipeline
+namespace MediatR.Pipeline
 {
+    using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -14,7 +15,8 @@
         /// </summary>
         /// <param name="request">Request instance</param>
         /// <param name="response">Response instance</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>An awaitable task</returns>
-        Task Process(TRequest request, TResponse response);
+        Task Process(TRequest request, TResponse response, CancellationToken cancellationToken);
     }
 }

--- a/src/MediatR/Pipeline/RequestPostProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestPostProcessorBehavior.cs
@@ -24,7 +24,7 @@ namespace MediatR.Pipeline
 
             foreach (var processor in _postProcessors)
             {
-                await processor.Process(request, response).ConfigureAwait(false);
+                await processor.Process(request, response, cancellationToken).ConfigureAwait(false);
             }
 
             return response;

--- a/test/MediatR.Tests/Pipeline/RequestPostProcessorTests.cs
+++ b/test/MediatR.Tests/Pipeline/RequestPostProcessorTests.cs
@@ -30,7 +30,7 @@ namespace MediatR.Tests.Pipeline
 
         public class PingPongPostProcessor : IRequestPostProcessor<Ping, Pong>
         {
-            public Task Process(Ping request, Pong response)
+            public Task Process(Ping request, Pong response, CancellationToken cancellationToken)
             {
                 response.Message = response.Message + " " + request.Message;
 


### PR DESCRIPTION
I'm the need of using IRequestPostProcessor, and wanted to make sure I can pass all the way down the CancellationToken.
This most likely be a broken change?