### PR TITLE
Non-generic Send request method

### DIFF
--- a/src/MediatR/IMediator.cs
+++ b/src/MediatR/IMediator.cs
@@ -19,6 +19,14 @@ namespace MediatR
         Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Asynchronously send an object request to a single handler via dynamic dispatch
+        /// </summary>
+        /// <param name="request">Request object</param>
+        /// <param name="cancellationToken">Optional cancellation token</param>
+        /// <returns>A task that represents the send operation. The task result contains the type erased handler response</returns>
+        Task<object> Send(object request, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Asynchronously send a notification to multiple handlers
         /// </summary>
         /// <param name="notification">Notification object</param>

--- a/src/MediatR/Internal/RequestHandlerWrapper.cs
+++ b/src/MediatR/Internal/RequestHandlerWrapper.cs
@@ -7,6 +7,9 @@ namespace MediatR.Internal
 
     internal abstract class RequestHandlerBase
     {
+        public abstract Task<object> Handle(object request, CancellationToken cancellationToken,
+            ServiceFactory serviceFactory);
+
         protected static THandler GetHandler<THandler>(ServiceFactory factory)
         {
             THandler handler;
@@ -38,6 +41,13 @@ namespace MediatR.Internal
     internal class RequestHandlerWrapperImpl<TRequest, TResponse> : RequestHandlerWrapper<TResponse>
         where TRequest : IRequest<TResponse>
     {
+        public override Task<object> Handle(object request, CancellationToken cancellationToken,
+            ServiceFactory serviceFactory)
+        {
+            return Handle((IRequest<TResponse>)request, cancellationToken, serviceFactory)
+                .ContinueWith(t => (object) t.Result);
+        }
+
         public override Task<TResponse> Handle(IRequest<TResponse> request, CancellationToken cancellationToken,
             ServiceFactory serviceFactory)
         {

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -4,6 +4,7 @@ namespace MediatR
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -47,7 +48,7 @@ namespace MediatR
                 throw new ArgumentNullException(nameof(request));
             }
             var requestType = request.GetType();
-            var requestInterfaceType = Array.Find(requestType.GetInterfaces(),
+            var requestInterfaceType = requestType.GetInterfaces().FirstOrDefault(
                 i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IRequest<>) );
             bool isValidRequest = requestInterfaceType != null;
             if(isValidRequest)

--- a/test/MediatR.Tests/SendTests.cs
+++ b/test/MediatR.Tests/SendTests.cs
@@ -38,7 +38,7 @@ namespace MediatR.Tests
                     scanner.AssemblyContainingType(typeof(PublishTests));
                     scanner.IncludeNamespaceContainingType<Ping>();
                     scanner.WithDefaultConventions();
-                    scanner.AddAllTypesOf(typeof (IRequestHandler<,>));
+                    scanner.AddAllTypesOf(typeof(IRequestHandler<,>));
                 });
                 cfg.For<ServiceFactory>().Use<ServiceFactory>(ctx => t => ctx.GetInstance(t));
                 cfg.For<IMediator>().Use<Mediator>();
@@ -61,18 +61,19 @@ namespace MediatR.Tests
                     scanner.AssemblyContainingType(typeof(PublishTests));
                     scanner.IncludeNamespaceContainingType<Ping>();
                     scanner.WithDefaultConventions();
-                    scanner.AddAllTypesOf(typeof (IRequestHandler<,>));
+                    scanner.AddAllTypesOf(typeof(IRequestHandler<,>));
                 });
-                cfg.For<ServiceFactory>().Use<ServiceFactory>(ctx => t => ctx.GetInstance(t));
+                cfg.For<ServiceFactory>().Use<ServiceFactory>(ctx => ctx.GetInstance);
                 cfg.For<IMediator>().Use<Mediator>();
             });
 
             var mediator = container.GetInstance<IMediator>();
 
-            object request = (object)new Ping{ Message = "Ping" };
+            object request = new Ping { Message = "Ping" };
             var response = await mediator.Send(request);
 
-            (response as Pong).Message.ShouldBe("Ping Pong");
+            var pong = response.ShouldBeOfType<Pong>();
+            pong.Message.ShouldBe("Ping Pong");
         }
     }
 }


### PR DESCRIPTION
This PR tries to resolve issue reported in: https://github.com/jbogard/MediatR/issues/385

by Adding a non generic API for IMediator interface:

```
Task<object> Send(object request, CancellationToken cancellationToken)
```
