### PR TITLE
Add INotification and CancellationToken to PublishCore

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <Authors>Jimmy Bogard</Authors>
     <LangVersion>latest</LangVersion>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/samples/MediatR.Examples.PublishStrategies/CustomMediator.cs
+++ b/samples/MediatR.Examples.PublishStrategies/CustomMediator.cs
@@ -1,21 +1,22 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace MediatR.Examples.PublishStrategies
 {
     public class CustomMediator : Mediator
     {
-        private Func<IEnumerable<Func<Task>>, Task> _publish;
+        private Func<IEnumerable<Func<INotification, CancellationToken, Task>>, INotification, CancellationToken, Task> _publish;
 
-        public CustomMediator(ServiceFactory serviceFactory, Func<IEnumerable<Func<Task>>, Task> publish) : base(serviceFactory)
+        public CustomMediator(ServiceFactory serviceFactory, Func<IEnumerable<Func<INotification, CancellationToken, Task>>, INotification, CancellationToken, Task> publish) : base(serviceFactory)
         {
             _publish = publish;
         }
 
-        protected override Task PublishCore(IEnumerable<Func<Task>> allHandlers)
+        protected override Task PublishCore(IEnumerable<Func<INotification, CancellationToken, Task>> allHandlers, INotification notification, CancellationToken cancellationToken)
         {
-            return _publish(allHandlers);
+            return _publish(allHandlers, notification, cancellationToken);
         }
     }
 }

--- a/samples/MediatR.Examples.PublishStrategies/Publisher.cs
+++ b/samples/MediatR.Examples.PublishStrategies/Publisher.cs
@@ -50,41 +50,41 @@ namespace MediatR.Examples.PublishStrategies
             return mediator.Publish(notification, cancellationToken);
         }
 
-        private Task ParallelWhenAll(IEnumerable<Func<Task>> handlers)
+        private Task ParallelWhenAll(IEnumerable<Func<INotification, CancellationToken, Task>> handlers, INotification notification, CancellationToken cancellationToken)
         {
             var tasks = new List<Task>();
 
             foreach (var handler in handlers)
             {
-                tasks.Add(Task.Run(() => handler()));
+                tasks.Add(Task.Run(() => handler(notification, cancellationToken)));
             }
 
             return Task.WhenAll(tasks);
         }
 
-        private Task ParallelWhenAny(IEnumerable<Func<Task>> handlers)
+        private Task ParallelWhenAny(IEnumerable<Func<INotification, CancellationToken, Task>> handlers, INotification notification, CancellationToken cancellationToken)
         {
             var tasks = new List<Task>();
 
             foreach (var handler in handlers)
             {
-                tasks.Add(Task.Run(() => handler()));
+                tasks.Add(Task.Run(() => handler(notification, cancellationToken)));
             }
 
             return Task.WhenAny(tasks);
         }
 
-        private Task ParallelNoWait(IEnumerable<Func<Task>> handlers)
+        private Task ParallelNoWait(IEnumerable<Func<INotification, CancellationToken, Task>> handlers, INotification notification, CancellationToken cancellationToken)
         {
             foreach (var handler in handlers)
             {
-                Task.Run(() => handler());
+                Task.Run(() => handler(notification, cancellationToken));
             }
 
             return Task.CompletedTask;
         }
 
-        private async Task AsyncContinueOnException(IEnumerable<Func<Task>> handlers)
+        private async Task AsyncContinueOnException(IEnumerable<Func<INotification, CancellationToken, Task>> handlers, INotification notification, CancellationToken cancellationToken)
         {
             var tasks = new List<Task>();
             var exceptions = new List<Exception>();
@@ -93,7 +93,7 @@ namespace MediatR.Examples.PublishStrategies
             {
                 try
                 {
-                    tasks.Add(handler());
+                    tasks.Add(handler(notification, cancellationToken));
                 }
                 catch (Exception ex) when (!(ex is OutOfMemoryException || ex is StackOverflowException))
                 {
@@ -120,15 +120,15 @@ namespace MediatR.Examples.PublishStrategies
             }
         }
 
-        private async Task SyncStopOnException(IEnumerable<Func<Task>> handlers)
+        private async Task SyncStopOnException(IEnumerable<Func<INotification, CancellationToken, Task>> handlers, INotification notification, CancellationToken cancellationToken)
         {
             foreach (var handler in handlers)
             {
-                await handler().ConfigureAwait(false);
+                await handler(notification, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        private async Task SyncContinueOnException(IEnumerable<Func<Task>> handlers)
+        private async Task SyncContinueOnException(IEnumerable<Func<INotification, CancellationToken, Task>> handlers, INotification notification, CancellationToken cancellationToken)
         {
             var exceptions = new List<Exception>();
 
@@ -136,7 +136,7 @@ namespace MediatR.Examples.PublishStrategies
             {
                 try
                 {
-                    await handler().ConfigureAwait(false);
+                    await handler(notification, cancellationToken).ConfigureAwait(false);
                 }
                 catch (AggregateException ex)
                 {

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -95,12 +95,14 @@ namespace MediatR
         /// Override in a derived class to control how the tasks are awaited. By default the implementation is a foreach and await of each handler
         /// </summary>
         /// <param name="allHandlers">Enumerable of tasks representing invoking each notification handler</param>
+        /// <param name="notification">The notification being published</param>
+        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>A task representing invoking all handlers</returns>
-        protected virtual async Task PublishCore(IEnumerable<Func<Task>> allHandlers)
+        protected virtual async Task PublishCore(IEnumerable<Func<INotification, CancellationToken, Task>> allHandlers, INotification notification, CancellationToken cancellationToken)
         {
             foreach (var handler in allHandlers)
             {
-                await handler().ConfigureAwait(false);
+                await handler(notification, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/test/MediatR.Tests/PublishTests.cs
+++ b/test/MediatR.Tests/PublishTests.cs
@@ -115,11 +115,11 @@ namespace MediatR.Tests
             {
             }
 
-            protected override async Task PublishCore(IEnumerable<Func<Task>> allHandlers)
+            protected override async Task PublishCore(IEnumerable<Func<INotification, CancellationToken, Task>> allHandlers, INotification notification, CancellationToken cancellationToken)
             {
                 foreach (var handler in allHandlers)
                 {
-                    await handler().ConfigureAwait(false);
+                    await handler(notification, cancellationToken).ConfigureAwait(false);
                 }
             }
         }


### PR DESCRIPTION
Related to #429 

This PR adds `INotification` and `CancellationToken` parameters to the `PublishCore` method. It opens  new possibilities for custom `Mediator` implementations.