### PR TITLE
Add ReferenceAssemblies so can compile on Mac/Linux

### DIFF
--- a/samples/MediatR.Examples.DryIocZero/MediatR.Examples.DryIocZero.csproj
+++ b/samples/MediatR.Examples.DryIocZero/MediatR.Examples.DryIocZero.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\MediatR\MediatR.csproj" />
     <ProjectReference Include="..\MediatR.Examples\MediatR.Examples.csproj" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MediatR.Examples.Ninject/MediatR.Examples.Ninject.csproj
+++ b/samples/MediatR.Examples.Ninject/MediatR.Examples.Ninject.csproj
@@ -20,6 +20,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/MediatR/MediatR.csproj
+++ b/src/MediatR/MediatR.csproj
@@ -19,6 +19,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/MediatR.Tests/MediatR.Tests.csproj
+++ b/test/MediatR.Tests/MediatR.Tests.csproj
@@ -25,6 +25,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adding the .NET Framework reference assemblies allows people on Mac or Linux to compile MediatR. 