### PR TITLE
simplify MinVer reference

### DIFF
--- a/src/MediatR/MediatR.csproj
+++ b/src/MediatR/MediatR.csproj
@@ -28,9 +28,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="2.3.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="MinVer" Version="2.3.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Unfortunately the tooling prefers the verbose variant, but this terse one is enough.