### PR TITLE
Defer handler reflection

### DIFF
--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -58,7 +58,7 @@ namespace MediatR
 
                     if (!isValidRequest)
                     {
-                        throw new ArgumentException($"{nameof(request)} does not implement ${nameof(IRequest)}");
+                        throw new ArgumentException($"{requestType.Name} does not implement {nameof(IRequest)}");
                     }
 
                     var responseType = requestInterfaceType!.GetGenericArguments()[0];

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -49,9 +49,9 @@ namespace MediatR
             }
             var requestType = request.GetType();
             var handler = _requestHandlers.GetOrAdd(requestType,
-                t =>
+                requestTypeKey =>
                 {
-                    var requestInterfaceType = requestType
+                    var requestInterfaceType = requestTypeKey
                         .GetInterfaces()
                         .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IRequest<>));
                     var isValidRequest = requestInterfaceType != null;
@@ -62,7 +62,7 @@ namespace MediatR
                     }
 
                     var responseType = requestInterfaceType!.GetGenericArguments()[0];
-                    return (RequestHandlerBase)Activator.CreateInstance(typeof(RequestHandlerWrapperImpl<,>).MakeGenericType(requestType, responseType));
+                    return (RequestHandlerBase)Activator.CreateInstance(typeof(RequestHandlerWrapperImpl<,>).MakeGenericType(requestTypeKey, responseType));
                 });
 
             // call via dynamic dispatch to avoid calling through reflection for performance reasons

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -58,7 +58,7 @@ namespace MediatR
 
                     if (!isValidRequest)
                     {
-                        throw new ArgumentException($"{requestType.Name} does not implement {nameof(IRequest)}");
+                        throw new ArgumentException($"{requestType.Name} does not implement {nameof(IRequest)}", nameof(request));
                     }
 
                     var responseType = requestInterfaceType!.GetGenericArguments()[0];

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -48,19 +48,22 @@ namespace MediatR
                 throw new ArgumentNullException(nameof(request));
             }
             var requestType = request.GetType();
-            var requestInterfaceType = requestType
-                .GetInterfaces()
-                .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IRequest<>));
-            var isValidRequest = requestInterfaceType != null;
-
-            if (!isValidRequest)
-            {
-                throw new ArgumentException($"{nameof(request)} does not implement ${nameof(IRequest)}");
-            }
-
-            var responseType = requestInterfaceType!.GetGenericArguments()[0];
             var handler = _requestHandlers.GetOrAdd(requestType,
-                t => Activator.CreateInstance(typeof(RequestHandlerWrapperImpl<,>).MakeGenericType(requestType, responseType)));
+                t =>
+                {
+                    var requestInterfaceType = requestType
+                        .GetInterfaces()
+                        .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IRequest<>));
+                    var isValidRequest = requestInterfaceType != null;
+
+                    if (!isValidRequest)
+                    {
+                        throw new ArgumentException($"{nameof(request)} does not implement ${nameof(IRequest)}");
+                    }
+
+                    var responseType = requestInterfaceType!.GetGenericArguments()[0];
+                    return Activator.CreateInstance(typeof(RequestHandlerWrapperImpl<,>).MakeGenericType(requestType, responseType));
+                });
 
             // call via dynamic dispatch to avoid calling through reflection for performance reasons
             return ((RequestHandlerBase) handler).Handle(request, cancellationToken, _serviceFactory);

--- a/test/MediatR.Tests/ExceptionTests.cs
+++ b/test/MediatR.Tests/ExceptionTests.cs
@@ -297,7 +297,7 @@ namespace MediatR.Tests
             object nonRequest = new NonRequest();
 
             var argumentException = await Should.ThrowAsync<ArgumentException>(async () => await mediator.Send(nonRequest));
-            Assert.Equal("NonRequest does not implement IRequest\r\nParameter name: request", argumentException.Message);
+            Assert.StartsWith("NonRequest does not implement IRequest", argumentException.Message);
         }
 
         public class NonRequest

--- a/test/MediatR.Tests/ExceptionTests.cs
+++ b/test/MediatR.Tests/ExceptionTests.cs
@@ -297,7 +297,7 @@ namespace MediatR.Tests
             object nonRequest = new NonRequest();
 
             var argumentException = await Should.ThrowAsync<ArgumentException>(async () => await mediator.Send(nonRequest));
-            Assert.Equal("NonRequest does not implement IRequest", argumentException.Message);
+            Assert.Equal("NonRequest does not implement IRequest\r\nParameter name: request", argumentException.Message);
         }
 
         public class NonRequest

--- a/test/MediatR.Tests/ExceptionTests.cs
+++ b/test/MediatR.Tests/ExceptionTests.cs
@@ -244,9 +244,9 @@ namespace MediatR.Tests
 
         public class PingException : IRequest
         {
- 
+
         }
- 
+
         public class PingExceptionHandler : IRequestHandler<PingException>
         {
             public Task<Unit> Handle(PingException request, CancellationToken cancellationToken)
@@ -254,7 +254,7 @@ namespace MediatR.Tests
                 throw new NotImplementedException();
             }
         }
- 
+
         [Fact]
         public async Task Should_throw_exception_for_non_generic_send_when_exception_occurs()
         {
@@ -271,9 +271,9 @@ namespace MediatR.Tests
                 cfg.For<IMediator>().Use<Mediator>();
             });
             var mediator = container.GetInstance<IMediator>();
- 
+
             object pingException = new PingException();
- 
+
             await Should.ThrowAsync<NotImplementedException>(async () => await mediator.Send(pingException));
         }
 
@@ -296,7 +296,8 @@ namespace MediatR.Tests
 
             object nonRequest = new NonRequest();
 
-            await Should.ThrowAsync<ArgumentException>(async () => await mediator.Send(nonRequest));
+            var argumentException = await Should.ThrowAsync<ArgumentException>(async () => await mediator.Send(nonRequest));
+            Assert.Equal("NonRequest does not implement IRequest", argumentException.Message);
         }
 
         public class NonRequest
@@ -320,9 +321,9 @@ namespace MediatR.Tests
                 cfg.For<IMediator>().Use<Mediator>();
             });
             var mediator = container.GetInstance<IMediator>();
- 
+
             PingException pingException = new PingException();
- 
+
             await Should.ThrowAsync<NotImplementedException>(async () => await mediator.Send(pingException));
         }
     }

--- a/test/MediatR.Tests/ExceptionTests.cs
+++ b/test/MediatR.Tests/ExceptionTests.cs
@@ -276,7 +276,34 @@ namespace MediatR.Tests
  
             await Should.ThrowAsync<NotImplementedException>(async () => await mediator.Send(pingException));
         }
- 
+
+        [Fact]
+        public async Task Should_throw_exception_for_non_request_send()
+        {
+            var container = new Container(cfg =>
+            {
+                cfg.Scan(scanner =>
+                {
+                    scanner.AssemblyContainingType(typeof(NullPinged));
+                    scanner.IncludeNamespaceContainingType<Ping>();
+                    scanner.WithDefaultConventions();
+                    scanner.AddAllTypesOf(typeof(IRequestHandler<,>));
+                });
+                cfg.For<ServiceFactory>().Use<ServiceFactory>(ctx => t => ctx.GetInstance(t));
+                cfg.For<IMediator>().Use<Mediator>();
+            });
+            var mediator = container.GetInstance<IMediator>();
+
+            object nonRequest = new NonRequest();
+
+            await Should.ThrowAsync<ArgumentException>(async () => await mediator.Send(nonRequest));
+        }
+
+        public class NonRequest
+        {
+
+        }
+
         [Fact]
         public async Task Should_throw_exception_for_generic_send_when_exception_occurs()
         {


### PR DESCRIPTION
no point doing the reflection on every send. only do it when _requestHandlers does not already contain a cached instance