### PR TITLE
remove redundant csproj settings

### DIFF
--- a/src/MediatR/MediatR.csproj
+++ b/src/MediatR/MediatR.csproj
@@ -8,8 +8,6 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <Features>strict</Features>
-    <AssemblyName>MediatR</AssemblyName>
-    <PackageId>MediatR</PackageId>
     <PackageTags>mediator;request;response;queries;commands;notifications</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\MediatR.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
since they default to the project name