### PR TITLE
feat: allow handlers to return a 'null' response

### DIFF
--- a/src/MediatR/IPipelineBehavior.cs
+++ b/src/MediatR/IPipelineBehavior.cs
@@ -9,7 +9,7 @@ namespace MediatR
     /// </summary>
     /// <typeparam name="TResponse">Response type</typeparam>
     /// <returns>Awaitable task returning a <typeparamref name="TResponse"/></returns>
-    public delegate Task<TResponse> RequestHandlerDelegate<TResponse>();
+    public delegate Task<TResponse?> RequestHandlerDelegate<TResponse>();
 
     /// <summary>
     /// Pipeline behavior to surround the inner handler.
@@ -26,6 +26,6 @@ namespace MediatR
         /// <param name="cancellationToken">Cancellation token</param>
         /// <param name="next">Awaitable delegate for the next action in the pipeline. Eventually this delegate represents the handler.</param>
         /// <returns>Awaitable task returning the <typeparamref name="TResponse"/></returns>
-        Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next);
+        Task<TResponse?> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next);
     }
 }

--- a/src/MediatR/IRequestHandler.cs
+++ b/src/MediatR/IRequestHandler.cs
@@ -17,7 +17,7 @@ namespace MediatR
         /// <param name="request">The request</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Response from the request</returns>
-        Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken);
+        Task<TResponse?> Handle(TRequest request, CancellationToken cancellationToken);
     }
 
     /// <summary>
@@ -60,7 +60,7 @@ namespace MediatR
     public abstract class RequestHandler<TRequest, TResponse> : IRequestHandler<TRequest, TResponse>
         where TRequest : IRequest<TResponse>
     {
-        Task<TResponse> IRequestHandler<TRequest, TResponse>.Handle(TRequest request, CancellationToken cancellationToken)
+        Task<TResponse?> IRequestHandler<TRequest, TResponse>.Handle(TRequest request, CancellationToken cancellationToken)
             => Task.FromResult(Handle(request));
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace MediatR
         /// </summary>
         /// <param name="request">Request</param>
         /// <returns>Response</returns>
-        protected abstract TResponse Handle(TRequest request);
+        protected abstract TResponse? Handle(TRequest request);
     }
 
     /// <summary>

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -24,7 +24,7 @@ namespace MediatR
         public Mediator(ServiceFactory serviceFactory) 
             => _serviceFactory = serviceFactory;
 
-        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)
+        public Task<TResponse?> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)
         {
             if (request == null)
             {

--- a/src/MediatR/Pipeline/IRequestPostProcessor.cs
+++ b/src/MediatR/Pipeline/IRequestPostProcessor.cs
@@ -17,6 +17,6 @@ namespace MediatR.Pipeline
         /// <param name="response">Response instance</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>An awaitable task</returns>
-        Task Process(TRequest request, TResponse response, CancellationToken cancellationToken);
+        Task Process(TRequest request, TResponse? response, CancellationToken cancellationToken);
     }
 }

--- a/src/MediatR/Pipeline/RequestExceptionActionProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestExceptionActionProcessorBehavior.cs
@@ -23,7 +23,7 @@ namespace MediatR.Pipeline
 
         public RequestExceptionActionProcessorBehavior(ServiceFactory serviceFactory) => _serviceFactory = serviceFactory;
 
-        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+        public async Task<TResponse?> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
         {
             try
             {

--- a/src/MediatR/Pipeline/RequestExceptionProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestExceptionProcessorBehavior.cs
@@ -23,7 +23,7 @@ namespace MediatR.Pipeline
 
         public RequestExceptionProcessorBehavior(ServiceFactory serviceFactory) => _serviceFactory = serviceFactory;
 
-        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+        public async Task<TResponse?> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
         {
             try
             {

--- a/src/MediatR/Pipeline/RequestPostProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestPostProcessorBehavior.cs
@@ -17,7 +17,7 @@ namespace MediatR.Pipeline
         public RequestPostProcessorBehavior(IEnumerable<IRequestPostProcessor<TRequest, TResponse>> postProcessors) 
             => _postProcessors = postProcessors;
 
-        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+        public async Task<TResponse?> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
         {
             var response = await next().ConfigureAwait(false);
 

--- a/src/MediatR/Pipeline/RequestPreProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestPreProcessorBehavior.cs
@@ -17,7 +17,7 @@ namespace MediatR.Pipeline
         public RequestPreProcessorBehavior(IEnumerable<IRequestPreProcessor<TRequest>> preProcessors) 
             => _preProcessors = preProcessors;
 
-        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+        public async Task<TResponse?> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
         {
             foreach (var processor in _preProcessors)
             {

--- a/src/MediatR/Wrappers/RequestHandlerWrapper.cs
+++ b/src/MediatR/Wrappers/RequestHandlerWrapper.cs
@@ -35,7 +35,7 @@ namespace MediatR.Wrappers
 
     public abstract class RequestHandlerWrapper<TResponse> : RequestHandlerBase
     {
-        public abstract Task<TResponse> Handle(IRequest<TResponse> request, CancellationToken cancellationToken,
+        public abstract Task<TResponse?> Handle(IRequest<TResponse> request, CancellationToken cancellationToken,
             ServiceFactory serviceFactory);
     }
 
@@ -54,10 +54,10 @@ namespace MediatR.Wrappers
                     return (object?)t.Result;
                 }, cancellationToken);
 
-        public override Task<TResponse> Handle(IRequest<TResponse> request, CancellationToken cancellationToken,
+        public override Task<TResponse?> Handle(IRequest<TResponse> request, CancellationToken cancellationToken,
             ServiceFactory serviceFactory)
         {
-            Task<TResponse> Handler() => GetHandler<IRequestHandler<TRequest, TResponse>>(serviceFactory).Handle((TRequest) request, cancellationToken);
+            Task<TResponse?> Handler() => GetHandler<IRequestHandler<TRequest, TResponse>>(serviceFactory).Handle((TRequest) request, cancellationToken);
 
             return serviceFactory
                 .GetInstances<IPipelineBehavior<TRequest, TResponse>>()


### PR DESCRIPTION
I have a use case where I want response handlers to be able to return null. Using `return null!` works, so there is nothing in the library preventing null responses except the nullable metadata. I know changing the nullable metadata is breaking change, but I thought I would open this PR for consideration anyway so that the nullability metadata can be made accurate.

Sorry if there is an existing issue for this. I did search, but did not find one.