### PR TITLE
Make unit readonly

### DIFF
--- a/src/MediatR/Unit.cs
+++ b/src/MediatR/Unit.cs
@@ -6,17 +6,19 @@
     /// <summary>
     /// Represents a void type, since <see cref="System.Void"/> is not a valid return type in C#.
     /// </summary>
-    public struct Unit : IEquatable<Unit>, IComparable<Unit>, IComparable
+    public readonly struct Unit : IEquatable<Unit>, IComparable<Unit>, IComparable
     {
+        private static readonly Unit _value = new();
+
         /// <summary>
         /// Default and only value of the <see cref="Unit"/> type.
         /// </summary>
-        public static readonly Unit Value = new();
+        public static ref readonly Unit Value => ref _value;
 
         /// <summary>
         /// Task from a <see cref="Unit"/> type.
         /// </summary>
-        public static readonly Task<Unit> Task = System.Threading.Tasks.Task.FromResult(Value);
+        public static Task<Unit> Task { get; } = System.Threading.Tasks.Task.FromResult(_value);
 
         /// <summary>
         /// Compares the current object with another object of the same type.


### PR DESCRIPTION
This minor change makes the `Unit` struct safe to be passed using `in` or `ref` without the compiler making a defensive copy.

The change to upgrade `Task` to a property is not strictly necessary but I am trying to keep this consistent with the change to `Value`.

The only breaking change I can see is that the upgrade of `Value` and `Task` from field to property is not binary compatible.