### PR TITLE
Use explicit Interface types vs object in ISender and IPublisher.

### DIFF
--- a/samples/MediatR.Examples.PublishStrategies/Publisher.cs
+++ b/samples/MediatR.Examples.PublishStrategies/Publisher.cs
@@ -25,22 +25,22 @@ namespace MediatR.Examples.PublishStrategies
         public IDictionary<PublishStrategy, IMediator> PublishStrategies = new Dictionary<PublishStrategy, IMediator>();
         public PublishStrategy DefaultStrategy { get; set; } = PublishStrategy.SyncContinueOnException;
 
-        public Task Publish<TNotification>(TNotification notification)
+        public Task Publish<TNotification>(TNotification notification) where TNotification : INotification
         {
             return Publish(notification, DefaultStrategy, default(CancellationToken));
         }
 
-        public Task Publish<TNotification>(TNotification notification, PublishStrategy strategy)
+        public Task Publish<TNotification>(TNotification notification, PublishStrategy strategy) where TNotification : INotification
         {
             return Publish(notification, strategy, default(CancellationToken));
         }
 
-        public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken)
+        public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken) where TNotification : INotification
         {
             return Publish(notification, DefaultStrategy, cancellationToken);
         }
 
-        public Task Publish<TNotification>(TNotification notification, PublishStrategy strategy, CancellationToken cancellationToken)
+        public Task Publish<TNotification>(TNotification notification, PublishStrategy strategy, CancellationToken cancellationToken) where TNotification : INotification
         {
             if (!PublishStrategies.TryGetValue(strategy, out var mediator))
             {

--- a/src/MediatR/IPublisher.cs
+++ b/src/MediatR/IPublisher.cs
@@ -14,7 +14,7 @@ namespace MediatR
         /// <param name="notification">Notification object</param>
         /// <param name="cancellationToken">Optional cancellation token</param>
         /// <returns>A task that represents the publish operation.</returns>
-        Task Publish(object notification, CancellationToken cancellationToken = default);
+        Task Publish(INotification notification, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Asynchronously send a notification to multiple handlers

--- a/src/MediatR/ISender.cs
+++ b/src/MediatR/ISender.cs
@@ -23,6 +23,6 @@ namespace MediatR
         /// <param name="request">Request object</param>
         /// <param name="cancellationToken">Optional cancellation token</param>
         /// <returns>A task that represents the send operation. The task result contains the type erased handler response</returns>
-        Task<object?> Send(object request, CancellationToken cancellationToken = default);
+        Task<object?> Send(IRequest request, CancellationToken cancellationToken = default);
     }
 }

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -86,7 +86,6 @@ namespace MediatR
             {
                 null => throw new ArgumentNullException(nameof(notification)),
                 INotification instance => PublishNotification(instance, cancellationToken),
-                //_ => throw new ArgumentException($"{nameof(notification)} does not implement ${nameof(INotification)}")
             };
 
         /// <summary>

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -81,12 +81,12 @@ namespace MediatR
             return PublishNotification(notification, cancellationToken);
         }
 
-        public Task Publish(object notification, CancellationToken cancellationToken = default) =>
+        public Task Publish(INotification notification, CancellationToken cancellationToken = default) =>
             notification switch
             {
                 null => throw new ArgumentNullException(nameof(notification)),
                 INotification instance => PublishNotification(instance, cancellationToken),
-                _ => throw new ArgumentException($"{nameof(notification)} does not implement ${nameof(INotification)}")
+                //_ => throw new ArgumentException($"{nameof(notification)} does not implement ${nameof(INotification)}")
             };
 
         /// <summary>

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -40,7 +40,7 @@ namespace MediatR
             return handler.Handle(request, cancellationToken, _serviceFactory);
         }
 
-        public Task<object?> Send(object request, CancellationToken cancellationToken = default)
+        public Task<object?> Send(IRequest request, CancellationToken cancellationToken = default)
         {
             if (request == null)
             {

--- a/test/MediatR.Tests/ExceptionTests.cs
+++ b/test/MediatR.Tests/ExceptionTests.cs
@@ -220,28 +220,6 @@ namespace MediatR.Tests
             await Should.ThrowAsync<ArgumentNullException>(async () => await mediator.Publish(notification));
         }
 
-        //[Fact]
-        //public async Task Should_throw_argument_exception_for_publish_when_request_is_not_notification()
-        //{
-        //    var container = new Container(cfg =>
-        //    {
-        //        cfg.Scan(scanner =>
-        //        {
-        //            scanner.AssemblyContainingType(typeof(NullPinged));
-        //            scanner.IncludeNamespaceContainingType<Ping>();
-        //            scanner.WithDefaultConventions();
-        //            scanner.AddAllTypesOf(typeof(IRequestHandler<,>));
-        //        });
-        //        cfg.For<ServiceFactory>().Use<ServiceFactory>(ctx => t => ctx.GetInstance(t));
-        //        cfg.For<IMediator>().Use<Mediator>();
-        //    });
-        //    var mediator = container.GetInstance<IMediator>();
-
-        //    object notification = "totally not notification";
-
-        //    await Should.ThrowAsync<ArgumentException>(async () => await mediator.Publish(notification));
-        //}
-
         public class PingException : IRequest
         {
 
@@ -276,34 +254,6 @@ namespace MediatR.Tests
 
             await Should.ThrowAsync<NotImplementedException>(async () => await mediator.Send(pingException));
         }
-
-        // [Fact]
-        // public async Task Should_throw_exception_for_non_request_send()
-        // {
-        //     var container = new Container(cfg =>
-        //     {
-        //         cfg.Scan(scanner =>
-        //         {
-        //             scanner.AssemblyContainingType(typeof(NullPinged));
-        //             scanner.IncludeNamespaceContainingType<Ping>();
-        //             scanner.WithDefaultConventions();
-        //             scanner.AddAllTypesOf(typeof(IRequestHandler<,>));
-        //         });
-        //         cfg.For<ServiceFactory>().Use<ServiceFactory>(ctx => t => ctx.GetInstance(t));
-        //         cfg.For<IMediator>().Use<Mediator>();
-        //     });
-        //     var mediator = container.GetInstance<IMediator>();
-
-        //     var nonRequest = new NonRequest();
-
-        //     var argumentException = await Should.ThrowAsync<ArgumentException>(async () => await mediator.Send(nonRequest));
-        //     Assert.StartsWith("NonRequest does not implement IRequest", argumentException.Message);
-        // }
-
-        // public class NonRequest : IRequest
-        // {
-
-        // }
 
         [Fact]
         public async Task Should_throw_exception_for_generic_send_when_exception_occurs()

--- a/test/MediatR.Tests/ExceptionTests.cs
+++ b/test/MediatR.Tests/ExceptionTests.cs
@@ -272,38 +272,38 @@ namespace MediatR.Tests
             });
             var mediator = container.GetInstance<IMediator>();
 
-            object pingException = new PingException();
+            var pingException = new PingException();
 
             await Should.ThrowAsync<NotImplementedException>(async () => await mediator.Send(pingException));
         }
 
-        [Fact]
-        public async Task Should_throw_exception_for_non_request_send()
-        {
-            var container = new Container(cfg =>
-            {
-                cfg.Scan(scanner =>
-                {
-                    scanner.AssemblyContainingType(typeof(NullPinged));
-                    scanner.IncludeNamespaceContainingType<Ping>();
-                    scanner.WithDefaultConventions();
-                    scanner.AddAllTypesOf(typeof(IRequestHandler<,>));
-                });
-                cfg.For<ServiceFactory>().Use<ServiceFactory>(ctx => t => ctx.GetInstance(t));
-                cfg.For<IMediator>().Use<Mediator>();
-            });
-            var mediator = container.GetInstance<IMediator>();
+        // [Fact]
+        // public async Task Should_throw_exception_for_non_request_send()
+        // {
+        //     var container = new Container(cfg =>
+        //     {
+        //         cfg.Scan(scanner =>
+        //         {
+        //             scanner.AssemblyContainingType(typeof(NullPinged));
+        //             scanner.IncludeNamespaceContainingType<Ping>();
+        //             scanner.WithDefaultConventions();
+        //             scanner.AddAllTypesOf(typeof(IRequestHandler<,>));
+        //         });
+        //         cfg.For<ServiceFactory>().Use<ServiceFactory>(ctx => t => ctx.GetInstance(t));
+        //         cfg.For<IMediator>().Use<Mediator>();
+        //     });
+        //     var mediator = container.GetInstance<IMediator>();
 
-            object nonRequest = new NonRequest();
+        //     var nonRequest = new NonRequest();
 
-            var argumentException = await Should.ThrowAsync<ArgumentException>(async () => await mediator.Send(nonRequest));
-            Assert.StartsWith("NonRequest does not implement IRequest", argumentException.Message);
-        }
+        //     var argumentException = await Should.ThrowAsync<ArgumentException>(async () => await mediator.Send(nonRequest));
+        //     Assert.StartsWith("NonRequest does not implement IRequest", argumentException.Message);
+        // }
 
-        public class NonRequest
-        {
+        // public class NonRequest : IRequest
+        // {
 
-        }
+        // }
 
         [Fact]
         public async Task Should_throw_exception_for_generic_send_when_exception_occurs()

--- a/test/MediatR.Tests/ExceptionTests.cs
+++ b/test/MediatR.Tests/ExceptionTests.cs
@@ -215,32 +215,32 @@ namespace MediatR.Tests
             });
             var mediator = container.GetInstance<IMediator>();
 
-            object notification = null;
+            INotification notification = null;
 
             await Should.ThrowAsync<ArgumentNullException>(async () => await mediator.Publish(notification));
         }
 
-        [Fact]
-        public async Task Should_throw_argument_exception_for_publish_when_request_is_not_notification()
-        {
-            var container = new Container(cfg =>
-            {
-                cfg.Scan(scanner =>
-                {
-                    scanner.AssemblyContainingType(typeof(NullPinged));
-                    scanner.IncludeNamespaceContainingType<Ping>();
-                    scanner.WithDefaultConventions();
-                    scanner.AddAllTypesOf(typeof(IRequestHandler<,>));
-                });
-                cfg.For<ServiceFactory>().Use<ServiceFactory>(ctx => t => ctx.GetInstance(t));
-                cfg.For<IMediator>().Use<Mediator>();
-            });
-            var mediator = container.GetInstance<IMediator>();
+        //[Fact]
+        //public async Task Should_throw_argument_exception_for_publish_when_request_is_not_notification()
+        //{
+        //    var container = new Container(cfg =>
+        //    {
+        //        cfg.Scan(scanner =>
+        //        {
+        //            scanner.AssemblyContainingType(typeof(NullPinged));
+        //            scanner.IncludeNamespaceContainingType<Ping>();
+        //            scanner.WithDefaultConventions();
+        //            scanner.AddAllTypesOf(typeof(IRequestHandler<,>));
+        //        });
+        //        cfg.For<ServiceFactory>().Use<ServiceFactory>(ctx => t => ctx.GetInstance(t));
+        //        cfg.For<IMediator>().Use<Mediator>();
+        //    });
+        //    var mediator = container.GetInstance<IMediator>();
 
-            object notification = "totally not notification";
+        //    object notification = "totally not notification";
 
-            await Should.ThrowAsync<ArgumentException>(async () => await mediator.Publish(notification));
-        }
+        //    await Should.ThrowAsync<ArgumentException>(async () => await mediator.Publish(notification));
+        //}
 
         public class PingException : IRequest
         {

--- a/test/MediatR.Tests/PublishTests.cs
+++ b/test/MediatR.Tests/PublishTests.cs
@@ -99,7 +99,7 @@ namespace MediatR.Tests
 
             var mediator = container.GetInstance<IMediator>();
 
-            object message = new Ping { Message = "Ping" };
+            var message = new Ping { Message = "Ping" };
             await mediator.Publish(message);
 
             var result = builder.ToString().Split(new [] {Environment.NewLine}, StringSplitOptions.None);

--- a/test/MediatR.Tests/SendTests.cs
+++ b/test/MediatR.Tests/SendTests.cs
@@ -69,7 +69,7 @@ namespace MediatR.Tests
 
             var mediator = container.GetInstance<IMediator>();
 
-            object request = new Ping { Message = "Ping" };
+            var request = new Ping { Message = "Ping" };
             var response = await mediator.Send(request);
 
             var pong = response.ShouldBeOfType<Pong>();


### PR DESCRIPTION
Update ISender Send method to take explicit `IRequest` instead of `object`
Update IPublisher Publish method to take explicit `INotification` instead of `object`

Giving us compile time checks vs runtime.

## Tests
Associated tests cases that are no longer required have been removed.
All other tests continue to pass.

I am not sure if this is a breaking change.  Technically the interface changes and thus some peoples code may not compile if they were using explicit `object`.  Which would mean this is a breaking change.  But they would have gotten a runtime error, where this will give a compile time error.