### PR TITLE
Add support to enable generic based interface defined handlers

### DIFF
--- a/src/MediatR/ISender.cs
+++ b/src/MediatR/ISender.cs
@@ -18,6 +18,17 @@ namespace MediatR
         Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Asynchronously send a request to a single handler
+        /// </summary>
+        /// <typeparam name="TRequest">Request type</typeparam>
+        /// <typeparam name="TResponse">Response type</typeparam>
+        /// <param name="request">Request object</param>
+        /// <param name="cancellationToken">Optional cancellation token</param>
+        /// <returns>A task that represents the send operation. The task result contains the handler response</returns>
+        Task<TResponse> Send<TRequest, TResponse>(TRequest request, CancellationToken cancellationToken = default)
+            where TRequest : IRequest<TResponse>;
+
+        /// <summary>
         /// Asynchronously send an object request to a single handler via dynamic dispatch
         /// </summary>
         /// <param name="request">Request object</param>

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -40,6 +40,21 @@ namespace MediatR
             return handler.Handle(request, cancellationToken, _serviceFactory);
         }
 
+        public Task<TResponse> Send<TRequest, TResponse>(TRequest request, CancellationToken cancellationToken = default)
+            where TRequest : IRequest<TResponse>
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            var handler = (RequestHandlerWrapper<TResponse>) _requestHandlers.GetOrAdd(typeof(TRequest),
+                static t => (RequestHandlerBase) (Activator.CreateInstance(typeof(RequestHandlerWrapperImpl<,>).MakeGenericType(t, typeof(TResponse)))
+                ?? throw new InvalidOperationException($"Could not create wrapper type for {t}")));
+
+            return handler.Handle(request, cancellationToken, _serviceFactory);
+        }
+
         public Task<object?> Send(object request, CancellationToken cancellationToken = default)
         {
             if (request == null)


### PR DESCRIPTION
When using Lamar on a project which made heavy use of generics, interfaces, and proxy objects this all worked fine. When it was used inside a project which used castle.windsor for the container, the handlers could not be loaded from the container as the use of the actual type of the request would not be registered in the container, but the underlying interfaces it was based on were.

This change allows for the send to support passing the request type to allow for a cleaner hint for the container to find the actual handler. 

I have included a tests which shows the exception of the container not able to find the handler, then one which uses the new method to load based on the interfaces