### PR TITLE
Bring back support for netstandard2.0 and net461

### DIFF
--- a/src/MediatR/MediatR.csproj
+++ b/src/MediatR/MediatR.csproj
@@ -4,7 +4,7 @@
     <Authors>Jimmy Bogard</Authors>
     <Description>Simple, unambitious mediator implementation in .NET</Description>
     <Copyright>Copyright Jimmy Bogard</Copyright>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Nullable>enable</Nullable>
     <Features>strict</Features>
     <PackageTags>mediator;request;response;queries;commands;notifications</PackageTags>
@@ -21,6 +21,10 @@
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net461'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+  </ItemGroup>
 
   <ItemGroup>
     <None Include="..\..\assets\logo\gradient_128x128.png" Pack="true" PackagePath="" />

--- a/test/MediatR.Tests/MediatR.Tests.csproj
+++ b/test/MediatR.Tests/MediatR.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
.NET Standard 2.0 and .NET Framework 4.6.1 support was removed because `IAsyncEnumerable` isn't supported:

> You can continue to use v9 just fine. V10 includes support for `IAsyncEnumerable` which doesn't have much support in full .NET. Since I don't use .NET 4.x and haven't for many years, I decided to move on to the LTS releases of .NET Core.
> https://github.com/jbogard/MediatR/issues/691#issuecomment-1009966065

Microsoft created a NuGet packages that brings support to `IAsyncEnumerable` to .NET Standard 2.0 and  .NET Framework 4.6.1: https://www.nuget.org/packages/Microsoft.Bcl.AsyncInterfaces/.
With this NuGet package, the latest commit in `master` [builds and all unit tests succeed on .NET Framework 4.6.1](https://github.com/GerardSmit/MediatR/runs/5159457252#step:5:190).

**Note:** I haven't reverted the `Microsoft.NETFramework.ReferenceAssemblies` reference that was removed in #671. The CI is running on Windows, so this package isn't necessarily. I can revert this back if needed.

---

Fixes #691
Reverts #671