### PR TITLE
MediatR.Examples.Windsor fix bug created by me before

### DIFF
--- a/samples/MediatR.Examples.Windsor/Program.cs
+++ b/samples/MediatR.Examples.Windsor/Program.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using Castle.MicroKernel;
 using Castle.MicroKernel.Registration;
 using Castle.Windsor;
 
@@ -34,8 +35,9 @@ internal class Program
         var fromAssemblyContainingPing = Classes.FromAssemblyContaining<Ping>();
         container.Register(fromAssemblyContainingPing.BasedOn(typeof(IRequestHandler<,>)).WithServiceAllInterfaces().AllowMultipleMatches());
         container.Register(fromAssemblyContainingPing.BasedOn(typeof(INotificationHandler<>)).WithServiceAllInterfaces().AllowMultipleMatches());
-        container.Register(Component.For(typeof(IPipelineBehavior<,>)).ImplementedBy(typeof(RequestExceptionActionProcessorBehavior<,>)));
         container.Register(Component.For(typeof(IPipelineBehavior<,>)).ImplementedBy(typeof(RequestExceptionProcessorBehavior<,>)));
+        container.Register(Component.For(typeof(IPipelineBehavior<,>)).ImplementedBy(typeof(RequestExceptionActionProcessorBehavior<,>)));
+        container.Register(fromAssemblyContainingPing.BasedOn(typeof(IRequestExceptionAction<,>)).WithServiceAllInterfaces().AllowMultipleMatches());
         container.Register(fromAssemblyContainingPing.BasedOn(typeof(IRequestExceptionHandler<,,>)).WithServiceAllInterfaces().AllowMultipleMatches());
         container.Register(fromAssemblyContainingPing.BasedOn(typeof(IStreamRequestHandler<,>)).WithServiceAllInterfaces().AllowMultipleMatches());
         container.Register(fromAssemblyContainingPing.BasedOn(typeof(IRequestPreProcessor<>)).WithServiceAllInterfaces().AllowMultipleMatches());
@@ -54,49 +56,19 @@ internal class Program
             var resolvedType = enumerableType != null ? k.ResolveAll(service) : k.Resolve(type);
             var genericArguments = service?.GetGenericArguments();
 
-            // Handle exceptions even using the base request types
-            if (service == null
-            || genericArguments == null
-            || !service.IsInterface
-            || !service.IsGenericType
-            || !service.IsConstructedGenericType
-            || !(service.GetGenericTypeDefinition()
-            ?.IsAssignableTo(typeof(IRequestExceptionHandler<,,>)) ?? false)
-            || genericArguments.Length != 3)
-            {
-                return resolvedType;
-            }
+            // Handle exceptions even using the base request types for IRequestExceptionHandler<,,>
+            var isRequestExceptionHandler = service?.GetGenericTypeDefinition()
+                ?.IsAssignableTo(typeof(IRequestExceptionHandler<,,>)) ?? false;
+            if (isRequestExceptionHandler)
+                return ResolveRequestExceptionHandler(k, type, service, resolvedType, genericArguments);
+
+            // Handle exceptions even using the base request types for IRequestExceptionAction<,>
+            var isRequestExceptionAction = service?.GetGenericTypeDefinition()
+                ?.IsAssignableTo(typeof(IRequestExceptionAction<,>)) ?? false;
+            if (isRequestExceptionAction)
+                return ResolveRequestExceptionAction(k, type, service, resolvedType, genericArguments);
             
-            var serviceFactory = k.Resolve<ServiceFactory>();
-            var baseRequestType = genericArguments[0].BaseType;
-            var response = genericArguments[1];
-            var exceptionType = genericArguments[2];
-
-            // Check if the base request type is valid
-            if (baseRequestType == null
-            || !baseRequestType.IsClass
-            || baseRequestType == typeof(object)
-            || ((!baseRequestType.GetInterfaces()
-                ?.Any(i => i.IsAssignableFrom(typeof(IRequest<>)))) ?? true))
-            {
-                return resolvedType;
-            }
-
-            var exceptionHandlerInterfaceType = typeof(IRequestExceptionHandler<,,>).MakeGenericType(baseRequestType, response, exceptionType);
-            var enumerableExceptionHandlerInterfaceType = typeof(IEnumerable<>).MakeGenericType(exceptionHandlerInterfaceType);
-
-            var firstArray = serviceFactory.Invoke(enumerableExceptionHandlerInterfaceType) as Array;
-            Debug.Assert(firstArray != null, $"Array '{nameof(firstArray)}' should not be null because this method calls ResolveAll when a {typeof(IEnumerable<>).FullName} " +
-                $"is passed as argument in argument named '{nameof(type)}'");
-
-            var secondArray = resolvedType is Array ? resolvedType as Array : new[] { resolvedType };
-            Debug.Assert(secondArray != null, $"Array '{nameof(secondArray)}' should not be null because '{nameof(resolvedType)}' is an array or created as an array");
-
-            var resultArray = Array.CreateInstance(typeof(object), firstArray.Length + secondArray.Length);
-            Array.Copy(firstArray, resultArray, firstArray.Length);
-            Array.Copy(secondArray, 0, resultArray, firstArray.Length, secondArray.Length);
-            
-            return resultArray;
+            return resolvedType;
         })));
 
         //Pipeline
@@ -112,5 +84,91 @@ internal class Program
         var mediator = container.Resolve<IMediator>();
 
         return mediator;
+    }
+
+    private static object ResolveRequestExceptionHandler(IKernel k, Type type, Type service, object resolvedType, Type[] genericArguments)
+    {
+        if (service == null
+        || genericArguments == null
+        || !service.IsInterface
+        || !service.IsGenericType
+        || !service.IsConstructedGenericType
+        || !(service.GetGenericTypeDefinition()
+        ?.IsAssignableTo(typeof(IRequestExceptionHandler<,,>)) ?? false)
+        || genericArguments.Length != 3)
+        {
+            return resolvedType;
+        }
+
+        var serviceFactory = k.Resolve<ServiceFactory>();
+        var baseRequestType = genericArguments[0].BaseType;
+        var response = genericArguments[1];
+        var exceptionType = genericArguments[2];
+
+        // Check if the base request type is valid
+        if (baseRequestType == null
+        || !baseRequestType.IsClass
+        || baseRequestType == typeof(object)
+        || ((!baseRequestType.GetInterfaces()
+            ?.Any(i => i.IsAssignableFrom(typeof(IRequest<>)))) ?? true))
+        {
+            return resolvedType;
+        }
+
+        var exceptionHandlerInterfaceType = typeof(IRequestExceptionHandler<,,>).MakeGenericType(baseRequestType, response, exceptionType);
+        var enumerableExceptionHandlerInterfaceType = typeof(IEnumerable<>).MakeGenericType(exceptionHandlerInterfaceType);
+        Array resultArray = CreateArraysOutOfResolvedTypeAndEnumerableInterfaceTypes(type, resolvedType, serviceFactory, enumerableExceptionHandlerInterfaceType);
+
+        return resultArray;
+    }
+
+    private static object ResolveRequestExceptionAction(IKernel k, Type type, Type service, object resolvedType, Type[] genericArguments)
+    {
+        if (service == null
+        || genericArguments == null
+        || !service.IsInterface
+        || !service.IsGenericType
+        || !service.IsConstructedGenericType
+        || !(service.GetGenericTypeDefinition()
+        ?.IsAssignableTo(typeof(IRequestExceptionAction<,>)) ?? false)
+        || genericArguments.Length != 2)
+        {
+            return resolvedType;
+        }
+
+        var serviceFactory = k.Resolve<ServiceFactory>();
+        var baseRequestType = genericArguments[0].BaseType;
+        var exceptionType = genericArguments[1];
+
+        // Check if the base request type is valid
+        if (baseRequestType == null
+        || !baseRequestType.IsClass
+        || baseRequestType == typeof(object)
+        || ((!baseRequestType.GetInterfaces()
+            ?.Any(i => i.IsAssignableFrom(typeof(IRequest<>)))) ?? true))
+        {
+            return resolvedType;
+        }
+
+        var exceptionHandlerInterfaceType = typeof(IRequestExceptionAction<,>).MakeGenericType(baseRequestType, exceptionType);
+        var enumerableExceptionHandlerInterfaceType = typeof(IEnumerable<>).MakeGenericType(exceptionHandlerInterfaceType);
+        Array resultArray = CreateArraysOutOfResolvedTypeAndEnumerableInterfaceTypes(type, resolvedType, serviceFactory, enumerableExceptionHandlerInterfaceType);
+
+        return resultArray;
+    }
+
+    private static Array CreateArraysOutOfResolvedTypeAndEnumerableInterfaceTypes(Type type, object resolvedType, ServiceFactory serviceFactory, Type enumerableExceptionHandlerInterfaceType)
+    {
+        var firstArray = serviceFactory.Invoke(enumerableExceptionHandlerInterfaceType) as Array;
+        Debug.Assert(firstArray != null, $"Array '{nameof(firstArray)}' should not be null because this method calls ResolveAll when a {typeof(IEnumerable<>).FullName} " +
+            $"is passed as argument in argument named '{nameof(type)}'");
+
+        var secondArray = resolvedType is Array ? resolvedType as Array : new[] { resolvedType };
+        Debug.Assert(secondArray != null, $"Array '{nameof(secondArray)}' should not be null because '{nameof(resolvedType)}' is an array or created as an array");
+
+        var resultArray = Array.CreateInstance(typeof(object), firstArray.Length + secondArray.Length);
+        Array.Copy(firstArray, resultArray, firstArray.Length);
+        Array.Copy(secondArray, 0, resultArray, firstArray.Length, secondArray.Length);
+        return resultArray;
     }
 }

--- a/samples/MediatR.Examples.Windsor/Program.cs
+++ b/samples/MediatR.Examples.Windsor/Program.cs
@@ -18,7 +18,7 @@ internal class Program
         var writer = new WrappingWriter(Console.Out);
         var mediator = BuildMediator(writer);
 
-        return Runner.Run(mediator, writer, "Castle.Windsor");
+        return Runner.Run(mediator, writer, "Castle.Windsor", true);
     }
 
     private static IMediator BuildMediator(WrappingWriter writer)
@@ -29,9 +29,16 @@ internal class Program
 
         // *** The default lifestyle for Windsor is Singleton
         // *** If you are using ASP.net, it's better to register your services with 'Per Web Request LifeStyle'.
-            
-        container.Register(Classes.FromAssemblyContaining<Ping>().BasedOn(typeof(IRequestHandler<,>)).WithServiceAllInterfaces());
-        container.Register(Classes.FromAssemblyContaining<Ping>().BasedOn(typeof(INotificationHandler<>)).WithServiceAllInterfaces());
+
+        var fromAssemblyContainingPing = Classes.FromAssemblyContaining<Ping>();
+        container.Register(fromAssemblyContainingPing.BasedOn(typeof(IRequestHandler<,>)).WithServiceAllInterfaces().AllowMultipleMatches());
+        container.Register(fromAssemblyContainingPing.BasedOn(typeof(INotificationHandler<>)).WithServiceAllInterfaces().AllowMultipleMatches());
+        container.Register(Component.For(typeof(IPipelineBehavior<,>)).ImplementedBy(typeof(RequestExceptionActionProcessorBehavior<,>)));
+        container.Register(Component.For(typeof(IPipelineBehavior<,>)).ImplementedBy(typeof(RequestExceptionProcessorBehavior<,>)));
+        container.Register(fromAssemblyContainingPing.BasedOn(typeof(IRequestExceptionHandler<,,>)).WithServiceAllInterfaces().AllowMultipleMatches());
+        container.Register(fromAssemblyContainingPing.BasedOn(typeof(IStreamRequestHandler<,>)).WithServiceAllInterfaces().AllowMultipleMatches());
+        container.Register(fromAssemblyContainingPing.BasedOn(typeof(IRequestPreProcessor<>)).WithServiceAllInterfaces().AllowMultipleMatches());
+        container.Register(fromAssemblyContainingPing.BasedOn(typeof(IRequestPostProcessor<,>)).WithServiceAllInterfaces().AllowMultipleMatches());
 
         container.Register(Component.For<IMediator>().ImplementedBy<Mediator>());
         container.Register(Component.For<TextWriter>().Instance(writer));
@@ -39,18 +46,61 @@ internal class Program
         {
             var enumerableType = type
                 .GetInterfaces()
-                .Concat(new [] {type})
-                .FirstOrDefault(t =>  t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+                .Concat(new[] { type })
+                .FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IEnumerable<>));
 
-            return enumerableType != null ? k.ResolveAll(enumerableType.GetGenericArguments()[0]) : k.Resolve(type);
+            var service = enumerableType?.GetGenericArguments()?[0];
+            var resolvedType = enumerableType != null ? k.ResolveAll(service) : k.Resolve(type);
+            var genericArguments = service?.GetGenericArguments();
+
+            // Handle exceptions even using the base request types
+            if (service == null
+            || genericArguments == null
+            || !service.IsInterface
+            || !service.IsGenericType
+            || !service.IsConstructedGenericType
+            || !(service.GetGenericTypeDefinition()
+            ?.IsAssignableTo(typeof(IRequestExceptionHandler<,,>)) ?? false)
+            || genericArguments.Length != 3
+            || !(genericArguments[0].BaseType?.IsClass ?? false))
+            {
+                return resolvedType;
+            }
+            
+            var serviceFactory = k.Resolve<ServiceFactory>();
+            var baseRequestType = genericArguments[0].BaseType;
+            var response = genericArguments[1];
+            var exceptionType = genericArguments[2];
+            
+            // Check if the base request type is valid
+            if (!baseRequestType.IsClass
+            || baseRequestType == typeof(object)
+            || ((!baseRequestType.GetInterfaces()
+                ?.Any(i => i.IsAssignableFrom(typeof(IRequest<>)))) ?? true))
+            {
+                return resolvedType;
+            }
+
+            var exceptionHandlerInterfaceType = typeof(IRequestExceptionHandler<,,>).MakeGenericType(baseRequestType, response, exceptionType);
+            var enumerableExceptionHandlerInterfaceType = typeof(IEnumerable<>).MakeGenericType(exceptionHandlerInterfaceType);
+
+            // This is assumed Array because this method calls ResolveAll when a IEnumerable<> is passed as argument
+            var firstArray = serviceFactory.Invoke(enumerableExceptionHandlerInterfaceType) as Array;
+            var secondArray = resolvedType is Array ? resolvedType as Array : new[] { resolvedType };
+            var resultArray = Array.CreateInstance(typeof(object), firstArray.Length + secondArray.Length);
+            Array.Copy(firstArray, resultArray, firstArray.Length);
+            Array.Copy(secondArray, 0, resultArray, firstArray.Length, secondArray.Length);
+            
+            return resultArray;
         })));
 
         //Pipeline
+        container.Register(Component.For(typeof(IStreamPipelineBehavior<,>)).ImplementedBy(typeof(GenericStreamPipelineBehavior<,>)));
         container.Register(Component.For(typeof(IPipelineBehavior<,>)).ImplementedBy(typeof(RequestPreProcessorBehavior<,>)).NamedAutomatically("PreProcessorBehavior"));
         container.Register(Component.For(typeof(IPipelineBehavior<,>)).ImplementedBy(typeof(RequestPostProcessorBehavior<,>)).NamedAutomatically("PostProcessorBehavior"));
         container.Register(Component.For(typeof(IPipelineBehavior<,>)).ImplementedBy(typeof(GenericPipelineBehavior<,>)).NamedAutomatically("Pipeline"));
         container.Register(Component.For(typeof(IRequestPreProcessor<>)).ImplementedBy(typeof(GenericRequestPreProcessor<>)).NamedAutomatically("PreProcessor"));
-        container.Register(Component.For(typeof(IRequestPostProcessor <,>)).ImplementedBy(typeof(GenericRequestPostProcessor<,>)).NamedAutomatically("PostProcessor"));
+        container.Register(Component.For(typeof(IRequestPostProcessor<,>)).ImplementedBy(typeof(GenericRequestPostProcessor<,>)).NamedAutomatically("PostProcessor"));
         container.Register(Component.For(typeof(IRequestPostProcessor<,>), typeof(ConstrainedRequestPostProcessor<,>)).NamedAutomatically("ConstrainedRequestPostProcessor"));
         container.Register(Component.For(typeof(INotificationHandler<>), typeof(ConstrainedPingedHandler<>)).NamedAutomatically("ConstrainedPingedHandler"));
 

--- a/samples/MediatR.Examples/ExceptionHandler/ExceptionsHandlers.cs
+++ b/samples/MediatR.Examples/ExceptionHandler/ExceptionsHandlers.cs
@@ -17,9 +17,7 @@ public class CommonExceptionHandler : AsyncRequestExceptionHandler<PingResource,
         RequestExceptionHandlerState<Pong> state,
         CancellationToken cancellationToken)
     {
-        // Exception type name required because it is checked later in messages
-        await _writer.WriteLineAsync($"Handling {exception.GetType().FullName}");
-        
+        // Exception type name must be written in messages by LogExceptionAction before
         // Exception handler type name required because it is checked later in messages
         await _writer.WriteLineAsync($"---- Exception Handler: '{typeof(CommonExceptionHandler).FullName}'").ConfigureAwait(false);
         
@@ -38,9 +36,7 @@ public class ConnectionExceptionHandler : IRequestExceptionHandler<PingResource,
         RequestExceptionHandlerState<Pong> state,
         CancellationToken cancellationToken)
     {
-        // Exception type name required because it is checked later in messages
-        await _writer.WriteLineAsync($"Handling {exception.GetType().FullName}");
-        
+        // Exception type name must be written in messages by LogExceptionAction before
         // Exception handler type name required because it is checked later in messages
         await _writer.WriteLineAsync($"---- Exception Handler: '{typeof(ConnectionExceptionHandler).FullName}'").ConfigureAwait(false);
         
@@ -59,9 +55,7 @@ public class AccessDeniedExceptionHandler : IRequestExceptionHandler<PingResourc
         RequestExceptionHandlerState<Pong> state,
         CancellationToken cancellationToken)
     {
-        // Exception type name required because it is checked later in messages
-        await _writer.WriteLineAsync($"Handling {exception.GetType().FullName}");
-        
+        // Exception type name must be written in messages by LogExceptionAction before
         // Exception handler type name required because it is checked later in messages
         await _writer.WriteLineAsync($"---- Exception Handler: '{typeof(AccessDeniedExceptionHandler).FullName}'").ConfigureAwait(false);
         
@@ -80,9 +74,7 @@ public class ServerExceptionHandler : IRequestExceptionHandler<PingNewResource, 
         RequestExceptionHandlerState<Pong> state,
         CancellationToken cancellationToken)
     {
-        // Exception type name required because it is checked later in messages
-        await _writer.WriteLineAsync($"Handling {exception.GetType().FullName}");
-
+        // Exception type name must be written in messages by LogExceptionAction before
         // Exception handler type name required because it is checked later in messages
         await _writer.WriteLineAsync($"---- Exception Handler: '{typeof(ServerExceptionHandler).FullName}'").ConfigureAwait(false);
         

--- a/samples/MediatR.Examples/ExceptionHandler/ExceptionsHandlersOverrides.cs
+++ b/samples/MediatR.Examples/ExceptionHandler/ExceptionsHandlersOverrides.cs
@@ -17,9 +17,7 @@ public class CommonExceptionHandler : AsyncRequestExceptionHandler<PingResourceT
         RequestExceptionHandlerState<Pong> state,
         CancellationToken cancellationToken)
     {
-        // Exception type name required because it is checked later in messages
-        await _writer.WriteLineAsync($"Handling {exception.GetType().FullName}");
-
+        // Exception type name must be written in messages by LogExceptionAction before
         // Exception handler type name required because it is checked later in messages
         await _writer.WriteLineAsync($"---- Exception Handler: '{typeof(CommonExceptionHandler).FullName}'").ConfigureAwait(false);
         
@@ -38,9 +36,7 @@ public class ServerExceptionHandler : ExceptionHandler.ServerExceptionHandler
         RequestExceptionHandlerState<Pong> state,
         CancellationToken cancellationToken)
     {
-        // Exception type name required because it is checked later in messages
-        await _writer.WriteLineAsync($"Handling {exception.GetType().FullName}");
-
+        // Exception type name must be written in messages by LogExceptionAction before
         // Exception handler type name required because it is checked later in messages
         await _writer.WriteLineAsync($"---- Exception Handler: '{typeof(ServerExceptionHandler).FullName}'").ConfigureAwait(false);
         

--- a/samples/MediatR.Examples/Runner.cs
+++ b/samples/MediatR.Examples/Runner.cs
@@ -280,6 +280,8 @@ public static class Runner
         where TException : Exception
     {
         var messages = writer.Contents.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None).ToList();
+        if (messages.Count - 3 < 0)
+            return false;
 
         // Note: For this handler type to be found in messages, it must be written in all tested exception handlers
         return messages[messages.Count - 2].Contains(typeof(THandler).FullName)

--- a/samples/MediatR.Examples/Runner.cs
+++ b/samples/MediatR.Examples/Runner.cs
@@ -283,7 +283,7 @@ public static class Runner
         if (messages.Count - 3 < 0)
             return false;
 
-        // Note: For this handler type to be found in messages, it must be written in all tested exception handlers
+        // Note: For this handler type to be found in messages, it must be written in messages by LogExceptionAction
         return messages[messages.Count - 2].Contains(typeof(THandler).FullName)
             // Note: For this exception type to be found in messages, exception must be written in all tested exception handlers
                && messages[messages.Count - 3].Contains(typeof(TException).FullName);


### PR DESCRIPTION
- Better checking of baseRequestType and checking assumptions with Debug.Assert instead of writing assumptions as comments
- Handling both request exception actions (that log the exception) and request exception handlers (that log the handler) in Program.cs in the correct order; extracted some methods in Program.cs and tried to give them meaningful names (sadly some methods could have better names though)
- Removed writing exception types in exception handlers after better understanding and wrote comments instead to understand what should actually write these exception names (LogExceptionAction from examples is actually writing exception names); sorry for this bug created by myself
- Added a small check in Runner.cs to ensure the method is not throwing an exception in case this method is called with less lines in messages list (split by end of lines)