### PR TITLE
fix bug concurrentdictionary GetOrAdd

### DIFF
--- a/Clean.bat
+++ b/Clean.bat
@@ -1,0 +1,6 @@
+FOR /d /r . %%d in (bin,obj) do @if exist "%%d" rd /s/q "%%d"
+FOR /F "tokens=*" %%G IN ('DIR /B /AD /S Packages') DO RMDIR /S /Q "%%G"
+FOR /F "tokens=*" %%G IN ('DIR /B /AD /S .vs') DO RMDIR /S /Q "%%G"
+FOR /F "tokens=*" %%G IN ('DIR /B /AD /S TestResults') DO RMDIR /S /Q "%%G"
+FOR /F "tokens=*" %%G IN ('DIR /B /AD /S AppPackages') DO RMDIR /S /Q "%%G"
+DEL /Q /F /S "*.csproj.user"

--- a/Clean.bat
+++ b/Clean.bat
@@ -1,6 +1,0 @@
-FOR /d /r . %%d in (bin,obj) do @if exist "%%d" rd /s/q "%%d"
-FOR /F "tokens=*" %%G IN ('DIR /B /AD /S Packages') DO RMDIR /S /Q "%%G"
-FOR /F "tokens=*" %%G IN ('DIR /B /AD /S .vs') DO RMDIR /S /Q "%%G"
-FOR /F "tokens=*" %%G IN ('DIR /B /AD /S TestResults') DO RMDIR /S /Q "%%G"
-FOR /F "tokens=*" %%G IN ('DIR /B /AD /S AppPackages') DO RMDIR /S /Q "%%G"
-DEL /Q /F /S "*.csproj.user"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,21 @@
 <Project>
   <PropertyGroup>
     <LangVersion>10.0</LangVersion>
-    <NoWarn>$(NoWarn);CS1701;CS1702;CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1701;CS1702;CS1591;VSTHRD200</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>
+
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.2.32">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/samples/MediatR.Examples.PublishStrategies/Publisher.cs
+++ b/samples/MediatR.Examples.PublishStrategies/Publisher.cs
@@ -78,7 +78,7 @@ public class Publisher
     {
         foreach (var handler in handlers)
         {
-            var task = Task.Run(() => handler(notification, cancellationToken));
+            _ = Task.Run(() => handler(notification, cancellationToken));
         }
 
         return Task.CompletedTask;

--- a/samples/MediatR.Examples.PublishStrategies/Publisher.cs
+++ b/samples/MediatR.Examples.PublishStrategies/Publisher.cs
@@ -78,7 +78,7 @@ public class Publisher
     {
         foreach (var handler in handlers)
         {
-            Task.Run(() => handler(notification, cancellationToken));
+            var task = Task.Run(() => handler(notification, cancellationToken));
         }
 
         return Task.CompletedTask;

--- a/samples/MediatR.Examples.Unity/Program.cs
+++ b/samples/MediatR.Examples.Unity/Program.cs
@@ -1,10 +1,10 @@
+using MediatR.Pipeline;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using MediatR.Pipeline;
 using Unity;
 using Unity.Lifetime;
 
@@ -12,14 +12,14 @@ namespace MediatR.Examples.Unity;
 
 internal class Program
 {
-    private static Task Main(string[] args)
+    private static async Task Main(string[] args)
     {
         var writer = new WrappingWriter(Console.Out);
         var mediator = BuildMediator(writer);
 
-        writer.WriteLine("Unity is not a very good container and breaks immediately");
+        await writer.WriteLineAsync("Unity is not a very good container and breaks immediately");
 
-        return Runner.Run(mediator, writer, "Unity");
+        await Runner.Run(mediator, writer, "Unity");
     }
 
     private static IMediator BuildMediator(WrappingWriter writer)

--- a/samples/MediatR.Examples/ExceptionHandler/LogExceptionAction.cs
+++ b/samples/MediatR.Examples/ExceptionHandler/LogExceptionAction.cs
@@ -12,6 +12,6 @@ public class LogExceptionAction : RequestExceptionAction<Ping>
 
     protected override void Execute(Ping request, Exception exception)
     {
-        _writer.WriteLineAsync($"--- Exception: '{exception.GetType().FullName}'");
+        _writer.WriteLine($"--- Exception: '{exception.GetType().FullName}'");
     }
 }

--- a/src/MediatR/Internal/LazyConcurrentDictionary.cs
+++ b/src/MediatR/Internal/LazyConcurrentDictionary.cs
@@ -6,7 +6,7 @@ namespace MediatR.Internal;
 
 //https://docs.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentdictionary-2.getoradd?view=net-6.0
 //https://andrewlock.net/making-getoradd-on-concurrentdictionary-thread-safe-using-lazy/
-internal sealed class LazyConcurrentDictionary<TKey, TValue> where TKey : notnull
+internal readonly struct LazyConcurrentDictionary<TKey, TValue> where TKey : notnull
 {
     private readonly ConcurrentDictionary<TKey, Lazy<TValue>> _concurrentDictionary;
 

--- a/src/MediatR/Internal/LazyConcurrentDictionary.cs
+++ b/src/MediatR/Internal/LazyConcurrentDictionary.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace MediatR.Internal;
+
+internal sealed class LazyConcurrentDictionary<TKey, TValue> where TKey : notnull
+{
+    private readonly ConcurrentDictionary<TKey, Lazy<TValue>> _concurrentDictionary;
+
+    public LazyConcurrentDictionary() => _concurrentDictionary = new ConcurrentDictionary<TKey, Lazy<TValue>>();
+
+    public TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory)
+    {
+        var lazyResult = _concurrentDictionary.GetOrAdd(key,
+            k => new Lazy<TValue>(() => valueFactory(k), LazyThreadSafetyMode.ExecutionAndPublication));
+        return lazyResult.Value;
+    }
+
+    public TValue AddOrUpdate(TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory)
+    {
+        var lazyResult = _concurrentDictionary.AddOrUpdate(
+            key,
+            new Lazy<TValue>(() => addValue, LazyThreadSafetyMode.ExecutionAndPublication),
+            (k, currentValue) => new Lazy<TValue>(() => updateValueFactory(k, currentValue.Value),
+                LazyThreadSafetyMode.ExecutionAndPublication));
+        return lazyResult.Value;
+    }
+
+
+    public TValue AddOrUpdate(TKey key, Func<TKey, TValue> addValueFactory,
+        Func<TKey, TValue, TValue> updateValueFactory)
+    {
+        var lazyResult = _concurrentDictionary.AddOrUpdate(
+            key,
+            k => new Lazy<TValue>(() => addValueFactory(k), LazyThreadSafetyMode.ExecutionAndPublication),
+            (k, currentValue) => new Lazy<TValue>(() => updateValueFactory(k, currentValue.Value),
+                LazyThreadSafetyMode.ExecutionAndPublication));
+        return lazyResult.Value;
+    }
+}

--- a/src/MediatR/Internal/LazyConcurrentDictionary.cs
+++ b/src/MediatR/Internal/LazyConcurrentDictionary.cs
@@ -4,6 +4,8 @@ using System.Threading;
 
 namespace MediatR.Internal;
 
+//https://docs.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentdictionary-2.getoradd?view=net-6.0
+//https://andrewlock.net/making-getoradd-on-concurrentdictionary-thread-safe-using-lazy/
 internal sealed class LazyConcurrentDictionary<TKey, TValue> where TKey : notnull
 {
     private readonly ConcurrentDictionary<TKey, Lazy<TValue>> _concurrentDictionary;

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -1,7 +1,8 @@
+using MediatR.Internal;
+
 namespace MediatR;
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -14,15 +15,15 @@ using Wrappers;
 public class Mediator : IMediator
 {
     private readonly ServiceFactory _serviceFactory;
-    private static readonly ConcurrentDictionary<Type, RequestHandlerBase> _requestHandlers = new();
-    private static readonly ConcurrentDictionary<Type, NotificationHandlerWrapper> _notificationHandlers = new();
-    private static readonly ConcurrentDictionary<Type, StreamRequestHandlerBase> _streamRequestHandlers = new();
+    private static readonly LazyConcurrentDictionary<Type, RequestHandlerBase> _requestHandlers = new();
+    private static readonly LazyConcurrentDictionary<Type, NotificationHandlerWrapper> _notificationHandlers = new();
+    private static readonly LazyConcurrentDictionary<Type, StreamRequestHandlerBase> _streamRequestHandlers = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Mediator"/> class.
     /// </summary>
     /// <param name="serviceFactory">The single instance factory.</param>
-    public Mediator(ServiceFactory serviceFactory) 
+    public Mediator(ServiceFactory serviceFactory)
         => _serviceFactory = serviceFactory;
 
     public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)
@@ -34,9 +35,9 @@ public class Mediator : IMediator
 
         var requestType = request.GetType();
 
-        var handler = (RequestHandlerWrapper<TResponse>)_requestHandlers.GetOrAdd(requestType,
-            static t => (RequestHandlerBase)(Activator.CreateInstance(typeof(RequestHandlerWrapperImpl<,>).MakeGenericType(t, typeof(TResponse)))
-                                             ?? throw new InvalidOperationException($"Could not create wrapper type for {t}")));
+        var handler = (RequestHandlerWrapper<TResponse>) _requestHandlers.GetOrAdd(requestType,
+            static t => (RequestHandlerBase) (Activator.CreateInstance(typeof(RequestHandlerWrapperImpl<,>).MakeGenericType(t, typeof(TResponse)))
+                                              ?? throw new InvalidOperationException($"Could not create wrapper type for {t}")));
 
         return handler.Handle(request, cancellationToken, _serviceFactory);
     }
@@ -63,7 +64,7 @@ public class Mediator : IMediator
                 var responseType = requestInterfaceType.GetGenericArguments()[0];
                 var wrapperType = typeof(RequestHandlerWrapperImpl<,>).MakeGenericType(requestTypeKey, responseType);
 
-                return (RequestHandlerBase)(Activator.CreateInstance(wrapperType) 
+                return (RequestHandlerBase) (Activator.CreateInstance(wrapperType)
                                             ?? throw new InvalidOperationException($"Could not create wrapper for type {wrapperType}"));
             });
 
@@ -109,7 +110,7 @@ public class Mediator : IMediator
     {
         var notificationType = notification.GetType();
         var handler = _notificationHandlers.GetOrAdd(notificationType,
-            static t => (NotificationHandlerWrapper) (Activator.CreateInstance(typeof(NotificationHandlerWrapperImpl<>).MakeGenericType(t)) 
+            static t => (NotificationHandlerWrapper) (Activator.CreateInstance(typeof(NotificationHandlerWrapperImpl<>).MakeGenericType(t))
                                                       ?? throw new InvalidOperationException($"Could not create wrapper for type {t}")));
 
         return handler.Handle(notification, cancellationToken, _serviceFactory, PublishCore);

--- a/test/MediatR.Benchmarks/MediatR.Benchmarks.csproj
+++ b/test/MediatR.Benchmarks/MediatR.Benchmarks.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.1" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/test/MediatR.Tests/MediatR.Tests.csproj
+++ b/test/MediatR.Tests/MediatR.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <NoWarn>$(NoWarn);VSTHRD002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,11 +11,11 @@
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
     <PackageReference Include="structuremap" Version="4.7.1" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
I had some big changes
1- As in the following documents. Using the GetOrAdd method is by no means Thread Safe. I added the test. If you test in Func during GetOrAdd, func will be called several times. But in the end one remains. This adds a lot of overhead to the program.
[microsoft](https://docs.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentdictionary-2.getoradd?view=net-6.0)
[andrewlock](https://andrewlock.net/making-getoradd-on-concurrentdictionary-thread-safe-using-lazy/)
2- Add an analyzer to increase the quality and maintenance of the code