### PR TITLE
Each matching exception handler/action is invoked at most once

### DIFF
--- a/src/MediatR.Contracts/MediatR.Contracts.csproj
+++ b/src/MediatR.Contracts/MediatR.Contracts.csproj
@@ -5,7 +5,7 @@
     <Authors>Jimmy Bogard</Authors>
     <Description>Contracts package for requests, responses, and notifications</Description>
     <Copyright>Copyright Jimmy Bogard</Copyright>
-    <TargetFrameworks>netstandard2.0;net461;</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <Features>strict</Features>
     <PackageTags>mediator;request;response;queries;commands;notifications</PackageTags>

--- a/src/MediatR/Pipeline/RequestExceptionActionProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestExceptionActionProcessorBehavior.cs
@@ -31,34 +31,26 @@ public class RequestExceptionActionProcessorBehavior<TRequest, TResponse> : IPip
         }
         catch (Exception exception)
         {
-            var attemptedActionTypes = new List<Type>();
+            var exceptionTypes = GetExceptionTypes(exception.GetType());
 
-            for (Type exceptionType = exception.GetType(); exceptionType != typeof(object); exceptionType = exceptionType.BaseType)
+            var actionsForException = exceptionTypes
+                .SelectMany(exceptionType => GetActionsForException(exceptionType, request))
+                .GroupBy(actionForException => actionForException.Action.GetType())
+                .Select(actionForException => actionForException.First())
+                .Select(actionForException => (MethodInfo: GetMethodInfoForAction(actionForException.ExceptionType), actionForException.Action))
+                .ToList();
+
+            foreach (var actionForException in actionsForException)
             {
-                var actionsForException = GetActionsForException(exceptionType, request, out MethodInfo actionMethod);
-
-                foreach (var actionForException in actionsForException)
+                try
                 {
-                    var actionType = actionForException.GetType();
-                    if (attemptedActionTypes.Contains(actionType))
-                    {
-                        continue;
-                    }
-                    else
-                    {
-                        attemptedActionTypes.Add(actionType);
-                    }
-
-                    try
-                    {
-                        await ((Task)(actionMethod.Invoke(actionForException, new object[] { request, exception, cancellationToken })
-                                      ?? throw new InvalidOperationException($"Could not create task for action method {actionMethod}."))).ConfigureAwait(false);
-                    }
-                    catch (TargetInvocationException invocationException) when (invocationException.InnerException != null)
-                    {
-                        // Unwrap invocation exception to throw the actual error
-                        ExceptionDispatchInfo.Capture(invocationException.InnerException).Throw();
-                    }
+                    await ((Task)(actionForException.MethodInfo.Invoke(actionForException.Action, new object[] { request, exception, cancellationToken })
+                                  ?? throw new InvalidOperationException($"Could not create task for action method {actionForException.MethodInfo}."))).ConfigureAwait(false);
+                }
+                catch (TargetInvocationException invocationException) when (invocationException.InnerException != null)
+                {
+                    // Unwrap invocation exception to throw the actual error
+                    ExceptionDispatchInfo.Capture(invocationException.InnerException).Throw();
                 }
             }
 
@@ -66,15 +58,35 @@ public class RequestExceptionActionProcessorBehavior<TRequest, TResponse> : IPip
         }
     }
 
-    private IList<object> GetActionsForException(Type exceptionType, TRequest request, out MethodInfo actionMethodInfo)
+    private static IEnumerable<Type> GetExceptionTypes(Type? exceptionType)
+    {
+        while (exceptionType != null && exceptionType != typeof(object))
+        {
+            yield return exceptionType;
+            exceptionType = exceptionType.BaseType;
+        }
+    }
+
+    private IEnumerable<(Type ExceptionType, object Action)> GetActionsForException(Type exceptionType, TRequest request)
     {
         var exceptionActionInterfaceType = typeof(IRequestExceptionAction<,>).MakeGenericType(typeof(TRequest), exceptionType);
         var enumerableExceptionActionInterfaceType = typeof(IEnumerable<>).MakeGenericType(exceptionActionInterfaceType);
-        actionMethodInfo = exceptionActionInterfaceType.GetMethod(nameof(IRequestExceptionAction<TRequest, Exception>.Execute))
-                           ?? throw new InvalidOperationException($"Could not find method {nameof(IRequestExceptionAction<TRequest, Exception>.Execute)} on type {exceptionActionInterfaceType}");
 
         var actionsForException = (IEnumerable<object>)_serviceFactory(enumerableExceptionActionInterfaceType);
 
-        return HandlersOrderer.Prioritize(actionsForException.ToList(), request);
+        return HandlersOrderer.Prioritize(actionsForException.ToList(), request)
+            .Select(action => (exceptionType, action));
+    }
+
+    private static MethodInfo GetMethodInfoForAction(Type exceptionType)
+    {
+        var exceptionActionInterfaceType = typeof(IRequestExceptionAction<,>).MakeGenericType(typeof(TRequest), exceptionType);
+
+        var actionMethodInfo =
+            exceptionActionInterfaceType.GetMethod(nameof(IRequestExceptionAction<TRequest, Exception>.Execute))
+            ?? throw new InvalidOperationException(
+                $"Could not find method {nameof(IRequestExceptionAction<TRequest, Exception>.Execute)} on type {exceptionActionInterfaceType}");
+
+        return actionMethodInfo;
     }
 }

--- a/src/MediatR/Pipeline/RequestExceptionActionProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestExceptionActionProcessorBehavior.cs
@@ -31,12 +31,24 @@ public class RequestExceptionActionProcessorBehavior<TRequest, TResponse> : IPip
         }
         catch (Exception exception)
         {
+            var attemptedActionTypes = new List<Type>();
+
             for (Type exceptionType = exception.GetType(); exceptionType != typeof(object); exceptionType = exceptionType.BaseType)
             {
                 var actionsForException = GetActionsForException(exceptionType, request, out MethodInfo actionMethod);
 
                 foreach (var actionForException in actionsForException)
                 {
+                    var actionType = actionForException.GetType();
+                    if (attemptedActionTypes.Contains(actionType))
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        attemptedActionTypes.Add(actionType);
+                    }
+
                     try
                     {
                         await ((Task)(actionMethod.Invoke(actionForException, new object[] { request, exception, cancellationToken })

--- a/src/MediatR/Pipeline/RequestExceptionActionProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestExceptionActionProcessorBehavior.cs
@@ -1,6 +1,6 @@
 namespace MediatR.Pipeline;
 
-using MediatR.Internal;
+using Internal;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/MediatR/Pipeline/RequestExceptionProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestExceptionProcessorBehavior.cs
@@ -33,6 +33,7 @@ public class RequestExceptionProcessorBehavior<TRequest, TResponse> : IPipelineB
         {
             var state = new RequestExceptionHandlerState<TResponse>();
             Type? exceptionType = null;
+            var attemptedHandlerTypes = new List<Type>();
 
             while (!state.Handled && exceptionType != typeof(Exception))
             {
@@ -42,6 +43,16 @@ public class RequestExceptionProcessorBehavior<TRequest, TResponse> : IPipelineB
 
                 foreach (var exceptionHandler in exceptionHandlers)
                 {
+                    var handlerType = exceptionHandler.GetType();
+                    if (attemptedHandlerTypes.Contains(handlerType))
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        attemptedHandlerTypes.Add(handlerType);
+                    }
+
                     try
                     {
                         await ((Task)(handleMethod.Invoke(exceptionHandler, new object[] { request, exception, state, cancellationToken })

--- a/src/MediatR/Pipeline/RequestExceptionProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestExceptionProcessorBehavior.cs
@@ -32,42 +32,32 @@ public class RequestExceptionProcessorBehavior<TRequest, TResponse> : IPipelineB
         catch (Exception exception)
         {
             var state = new RequestExceptionHandlerState<TResponse>();
-            Type? exceptionType = null;
-            var attemptedHandlerTypes = new List<Type>();
 
-            while (!state.Handled && exceptionType != typeof(Exception))
+            var exceptionTypes = GetExceptionTypes(exception.GetType());
+
+            var handlersForException = exceptionTypes
+                .SelectMany(exceptionType => GetHandlersForException(exceptionType, request))
+                .GroupBy(handlerForException => handlerForException.Handler.GetType())
+                .Select(handlerForException => handlerForException.First())
+                .Select(handlerForException => (MethodInfo: GetMethodInfoForHandler(handlerForException.ExceptionType), handlerForException.Handler))
+                .ToList();
+
+            foreach (var handlerForException in handlersForException)
             {
-                exceptionType = exceptionType == null ? exception.GetType() : exceptionType.BaseType
-                                                                              ?? throw new InvalidOperationException("Could not determine exception base type.");
-                var exceptionHandlers = GetExceptionHandlers(request, exceptionType, out MethodInfo handleMethod);
-
-                foreach (var exceptionHandler in exceptionHandlers)
+                try
                 {
-                    var handlerType = exceptionHandler.GetType();
-                    if (attemptedHandlerTypes.Contains(handlerType))
-                    {
-                        continue;
-                    }
-                    else
-                    {
-                        attemptedHandlerTypes.Add(handlerType);
-                    }
+                    await ((Task) (handlerForException.MethodInfo.Invoke(handlerForException.Handler, new object[] { request, exception, state, cancellationToken })
+                                   ?? throw new InvalidOperationException("Did not return a Task from the exception handler."))).ConfigureAwait(false);
+                }
+                catch (TargetInvocationException invocationException) when (invocationException.InnerException != null)
+                {
+                    // Unwrap invocation exception to throw the actual error
+                    ExceptionDispatchInfo.Capture(invocationException.InnerException).Throw();
+                }
 
-                    try
-                    {
-                        await ((Task)(handleMethod.Invoke(exceptionHandler, new object[] { request, exception, state, cancellationToken })
-                                      ?? throw new InvalidOperationException("Did not return a Task from the exception handler."))).ConfigureAwait(false);
-                    }
-                    catch (TargetInvocationException invocationException) when (invocationException.InnerException != null)
-                    {
-                        // Unwrap invocation exception to throw the actual error
-                        ExceptionDispatchInfo.Capture(invocationException.InnerException).Throw();
-                    }
-
-                    if (state.Handled)
-                    {
-                        break;
-                    }
+                if (state.Handled)
+                {
+                    break;
                 }
             }
 
@@ -84,16 +74,33 @@ public class RequestExceptionProcessorBehavior<TRequest, TResponse> : IPipelineB
             return state.Response; //cannot be null if Handled
         }
     }
+    private static IEnumerable<Type> GetExceptionTypes(Type? exceptionType)
+    {
+        while (exceptionType != null && exceptionType != typeof(object))
+        {
+            yield return exceptionType;
+            exceptionType = exceptionType.BaseType;
+        }
+    }
 
-    private IList<object> GetExceptionHandlers(TRequest request, Type exceptionType, out MethodInfo handleMethodInfo)
+    private IEnumerable<(Type ExceptionType, object Handler)> GetHandlersForException(Type exceptionType, TRequest request)
     {
         var exceptionHandlerInterfaceType = typeof(IRequestExceptionHandler<,,>).MakeGenericType(typeof(TRequest), typeof(TResponse), exceptionType);
         var enumerableExceptionHandlerInterfaceType = typeof(IEnumerable<>).MakeGenericType(exceptionHandlerInterfaceType);
-        handleMethodInfo = exceptionHandlerInterfaceType.GetMethod(nameof(IRequestExceptionHandler<TRequest, TResponse, Exception>.Handle))
+
+        var exceptionHandlers = (IEnumerable<object>) _serviceFactory(enumerableExceptionHandlerInterfaceType);
+
+        return HandlersOrderer.Prioritize(exceptionHandlers.ToList(), request)
+            .Select(handler => (exceptionType, action: handler));
+    }
+
+    private static MethodInfo GetMethodInfoForHandler(Type exceptionType)
+    {
+        var exceptionHandlerInterfaceType = typeof(IRequestExceptionHandler<,,>).MakeGenericType(typeof(TRequest), typeof(TResponse), exceptionType);
+        
+        var handleMethodInfo = exceptionHandlerInterfaceType.GetMethod(nameof(IRequestExceptionHandler<TRequest, TResponse, Exception>.Handle))
                            ?? throw new InvalidOperationException($"Could not find method {nameof(IRequestExceptionHandler<TRequest, TResponse, Exception>.Handle)} on type {exceptionHandlerInterfaceType}");
 
-        var exceptionHandlers = (IEnumerable<object>)_serviceFactory.Invoke(enumerableExceptionHandlerInterfaceType);
-
-        return HandlersOrderer.Prioritize(exceptionHandlers.ToList(), request);
+        return handleMethodInfo;
     }
 }

--- a/test/MediatR.Tests/Pipeline/RequestExceptionActionTests.cs
+++ b/test/MediatR.Tests/Pipeline/RequestExceptionActionTests.cs
@@ -49,6 +49,17 @@ public class RequestExceptionActionTests
         }
     }
 
+    public class GenericExceptionAction<TRequest> : IRequestExceptionAction<TRequest>
+    {
+        public int ExecutionCount { get; private set; }
+
+        public Task Execute(TRequest request, Exception exception, CancellationToken cancellationToken)
+        {
+            ExecutionCount++;
+            return Task.CompletedTask;
+        }
+    }
+
     public class PingPongExceptionAction<TRequest> : IRequestExceptionAction<TRequest, PingPongException>
     {
         public bool Executed { get; private set; }
@@ -83,7 +94,7 @@ public class RequestExceptionActionTests
     }
 
     [Fact]
-    public async Task Should_run_all_exception_handlers_that_match_base_type()
+    public async Task Should_run_all_exception_actions_that_match_base_type()
     {
         var pingExceptionAction = new PingExceptionAction();
         var pongExceptionAction = new PongExceptionAction();
@@ -107,5 +118,26 @@ public class RequestExceptionActionTests
         pingExceptionAction.Executed.ShouldBeTrue();
         pingPongExceptionAction.Executed.ShouldBeTrue();
         pongExceptionAction.Executed.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Should_run_matching_exception_actions_only_once()
+    {
+        var genericExceptionAction = new GenericExceptionAction<Ping>();
+        var container = new Container(cfg =>
+        {
+            cfg.For<IRequestHandler<Ping, Pong>>().Use<PingHandler>();
+            cfg.For<IRequestExceptionAction<Ping>>().Use(_ => genericExceptionAction);
+            cfg.For(typeof(IPipelineBehavior<,>)).Add(typeof(RequestExceptionActionProcessorBehavior<,>));
+            cfg.For<ServiceFactory>().Use<ServiceFactory>(ctx => t => ctx.GetInstance(t));
+            cfg.For<IMediator>().Use<Mediator>();
+        });
+
+        var mediator = container.GetInstance<IMediator>();
+
+        var request = new Ping { Message = "Ping!" };
+        await Assert.ThrowsAsync<PingException>(() => mediator.Send(request));
+
+        genericExceptionAction.ExecutionCount.ShouldBe(1);
     }
 }


### PR DESCRIPTION
Currently base exception handlers/actions will be executed multiple times when a derived exception is thrown. 
For example you have `MyExceptionHandler:IRequestExceptionHandler<MyRequest, MyResponse>`, it will be invoked twice when `MyException:Exception` is thrown. Its invocation count grows with the exception inheritance.

This PR fixes this bug by checking handler/action type, please note that checking interface types is not enough because different interfaces can share the same handler/action type.