### PR TITLE
CA1068: CancellationToken parameters must come last

### DIFF
--- a/src/MediatR/IPipelineBehavior.cs
+++ b/src/MediatR/IPipelineBehavior.cs
@@ -23,8 +23,8 @@ public interface IPipelineBehavior<in TRequest, TResponse> where TRequest : IReq
     /// Pipeline handler. Perform any additional behavior and await the <paramref name="next"/> delegate as necessary
     /// </summary>
     /// <param name="request">Incoming request</param>
-    /// <param name="cancellationToken">Cancellation token</param>
     /// <param name="next">Awaitable delegate for the next action in the pipeline. Eventually this delegate represents the handler.</param>
+    /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Awaitable task returning the <typeparamref name="TResponse"/></returns>
-    Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next);
+    Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken);
 }

--- a/src/MediatR/IStreamPipelineBehavior.cs
+++ b/src/MediatR/IStreamPipelineBehavior.cs
@@ -24,8 +24,8 @@ public interface IStreamPipelineBehavior<in TRequest, TResponse>
     /// Stream Pipeline handler. Perform any additional behavior and iterate the <paramref name="next"/> delegate as necessary
     /// </summary>
     /// <param name="request">Incoming request</param>
-    /// <param name="cancellationToken">Cancellation token</param>
     /// <param name="next">Awaitable delegate for the next action in the pipeline. Eventually this delegate represents the handler.</param>
+    /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Awaitable task returning the <typeparamref name="TResponse"/></returns>
-    IAsyncEnumerable<TResponse> Handle(TRequest request, CancellationToken cancellationToken, StreamHandlerDelegate<TResponse> next);
+    IAsyncEnumerable<TResponse> Handle(TRequest request, StreamHandlerDelegate<TResponse> next, CancellationToken cancellationToken);
 }

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -38,7 +38,7 @@ public class Mediator : IMediator
             static t => (RequestHandlerBase)(Activator.CreateInstance(typeof(RequestHandlerWrapperImpl<,>).MakeGenericType(t, typeof(TResponse)))
                                              ?? throw new InvalidOperationException($"Could not create wrapper type for {t}")));
 
-        return handler.Handle(request, cancellationToken, _serviceFactory);
+        return handler.Handle(request, _serviceFactory, cancellationToken);
     }
 
     public Task<object?> Send(object request, CancellationToken cancellationToken = default)
@@ -68,7 +68,7 @@ public class Mediator : IMediator
             });
 
         // call via dynamic dispatch to avoid calling through reflection for performance reasons
-        return handler.Handle(request, cancellationToken, _serviceFactory);
+        return handler.Handle(request, _serviceFactory, cancellationToken);
     }
 
     public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
@@ -112,7 +112,7 @@ public class Mediator : IMediator
             static t => (NotificationHandlerWrapper) (Activator.CreateInstance(typeof(NotificationHandlerWrapperImpl<>).MakeGenericType(t)) 
                                                       ?? throw new InvalidOperationException($"Could not create wrapper for type {t}")));
 
-        return handler.Handle(notification, cancellationToken, _serviceFactory, PublishCore);
+        return handler.Handle(notification, _serviceFactory, PublishCore, cancellationToken);
     }
 
 
@@ -128,7 +128,7 @@ public class Mediator : IMediator
         var streamHandler = (StreamRequestHandlerWrapper<TResponse>) _streamRequestHandlers.GetOrAdd(requestType,
             t => (StreamRequestHandlerBase) Activator.CreateInstance(typeof(StreamRequestHandlerWrapperImpl<,>).MakeGenericType(requestType, typeof(TResponse))));
 
-        var items = streamHandler.Handle(request, cancellationToken, _serviceFactory);
+        var items = streamHandler.Handle(request, _serviceFactory, cancellationToken);
 
         return items;
     }
@@ -161,7 +161,7 @@ public class Mediator : IMediator
             });
 
         // call via dynamic dispatch to avoid calling through reflection for performance reasons
-        var items = handler.Handle(request, cancellationToken, _serviceFactory);
+        var items = handler.Handle(request, _serviceFactory, cancellationToken);
 
         return items;
     }

--- a/src/MediatR/Pipeline/RequestExceptionActionProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestExceptionActionProcessorBehavior.cs
@@ -23,7 +23,7 @@ public class RequestExceptionActionProcessorBehavior<TRequest, TResponse> : IPip
 
     public RequestExceptionActionProcessorBehavior(ServiceFactory serviceFactory) => _serviceFactory = serviceFactory;
 
-    public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/MediatR/Pipeline/RequestExceptionProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestExceptionProcessorBehavior.cs
@@ -23,7 +23,7 @@ public class RequestExceptionProcessorBehavior<TRequest, TResponse> : IPipelineB
 
     public RequestExceptionProcessorBehavior(ServiceFactory serviceFactory) => _serviceFactory = serviceFactory;
 
-    public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/MediatR/Pipeline/RequestPostProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestPostProcessorBehavior.cs
@@ -17,7 +17,7 @@ public class RequestPostProcessorBehavior<TRequest, TResponse> : IPipelineBehavi
     public RequestPostProcessorBehavior(IEnumerable<IRequestPostProcessor<TRequest, TResponse>> postProcessors) 
         => _postProcessors = postProcessors;
 
-    public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
         var response = await next().ConfigureAwait(false);
 

--- a/src/MediatR/Pipeline/RequestPreProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestPreProcessorBehavior.cs
@@ -17,7 +17,7 @@ public class RequestPreProcessorBehavior<TRequest, TResponse> : IPipelineBehavio
     public RequestPreProcessorBehavior(IEnumerable<IRequestPreProcessor<TRequest>> preProcessors) 
         => _preProcessors = preProcessors;
 
-    public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
         foreach (var processor in _preProcessors)
         {

--- a/src/MediatR/Wrappers/NotificationHandlerWrapper.cs
+++ b/src/MediatR/Wrappers/NotificationHandlerWrapper.cs
@@ -8,15 +8,17 @@ using System.Threading.Tasks;
 
 public abstract class NotificationHandlerWrapper
 {
-    public abstract Task Handle(INotification notification, CancellationToken cancellationToken, ServiceFactory serviceFactory,
-        Func<IEnumerable<Func<INotification, CancellationToken, Task>>, INotification, CancellationToken, Task> publish);
+    public abstract Task Handle(INotification notification, ServiceFactory serviceFactory,
+        Func<IEnumerable<Func<INotification, CancellationToken, Task>>, INotification, CancellationToken, Task> publish,
+        CancellationToken cancellationToken);
 }
 
 public class NotificationHandlerWrapperImpl<TNotification> : NotificationHandlerWrapper
     where TNotification : INotification
 {
-    public override Task Handle(INotification notification, CancellationToken cancellationToken, ServiceFactory serviceFactory,
-        Func<IEnumerable<Func<INotification, CancellationToken, Task>>, INotification, CancellationToken, Task> publish)
+    public override Task Handle(INotification notification, ServiceFactory serviceFactory,
+        Func<IEnumerable<Func<INotification, CancellationToken, Task>>, INotification, CancellationToken, Task> publish,
+        CancellationToken cancellationToken)
     {
         var handlers = serviceFactory
             .GetInstances<INotificationHandler<TNotification>>()

--- a/src/MediatR/Wrappers/RequestHandlerWrapper.cs
+++ b/src/MediatR/Wrappers/RequestHandlerWrapper.cs
@@ -6,32 +6,32 @@ using System.Threading.Tasks;
 
 public abstract class RequestHandlerBase : HandlerBase
 {
-    public abstract Task<object?> Handle(object request, CancellationToken cancellationToken,
-        ServiceFactory serviceFactory);
+    public abstract Task<object?> Handle(object request, ServiceFactory serviceFactory,
+        CancellationToken cancellationToken);
 
 }
 
 public abstract class RequestHandlerWrapper<TResponse> : RequestHandlerBase
 {
-    public abstract Task<TResponse> Handle(IRequest<TResponse> request, CancellationToken cancellationToken,
-        ServiceFactory serviceFactory);
+    public abstract Task<TResponse> Handle(IRequest<TResponse> request, ServiceFactory serviceFactory,
+        CancellationToken cancellationToken);
 }
 
 public class RequestHandlerWrapperImpl<TRequest, TResponse> : RequestHandlerWrapper<TResponse>
     where TRequest : IRequest<TResponse>
 {
-    public override async Task<object?> Handle(object request, CancellationToken cancellationToken,
-        ServiceFactory serviceFactory) =>
-        await Handle((IRequest<TResponse>)request, cancellationToken, serviceFactory).ConfigureAwait(false);
+    public override async Task<object?> Handle(object request, ServiceFactory serviceFactory,
+        CancellationToken cancellationToken) =>
+        await Handle((IRequest<TResponse>)request, serviceFactory, cancellationToken).ConfigureAwait(false);
 
-    public override Task<TResponse> Handle(IRequest<TResponse> request, CancellationToken cancellationToken,
-        ServiceFactory serviceFactory)
+    public override Task<TResponse> Handle(IRequest<TResponse> request, ServiceFactory serviceFactory,
+        CancellationToken cancellationToken)
     {
         Task<TResponse> Handler() => GetHandler<IRequestHandler<TRequest, TResponse>>(serviceFactory).Handle((TRequest) request, cancellationToken);
 
         return serviceFactory
             .GetInstances<IPipelineBehavior<TRequest, TResponse>>()
             .Reverse()
-            .Aggregate((RequestHandlerDelegate<TResponse>) Handler, (next, pipeline) => () => pipeline.Handle((TRequest)request, cancellationToken, next))();
+            .Aggregate((RequestHandlerDelegate<TResponse>) Handler, (next, pipeline) => () => pipeline.Handle((TRequest)request, next, cancellationToken))();
     }
 }

--- a/test/MediatR.Tests/Pipeline/Streams/StreamPipelineBehaviorTests.cs
+++ b/test/MediatR.Tests/Pipeline/Streams/StreamPipelineBehaviorTests.cs
@@ -33,7 +33,7 @@ public class StreamPipelineBehaviorTests
 
     public class SingSongPipelineBehavior : IStreamPipelineBehavior<Sing, Song>
     {
-        public async IAsyncEnumerable<Song> Handle(Sing request, [EnumeratorCancellation] CancellationToken cancellationToken, StreamHandlerDelegate<Song> next)
+        public async IAsyncEnumerable<Song> Handle(Sing request, StreamHandlerDelegate<Song> next, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             yield return new Song { Message = "Start behaving..." };
 

--- a/test/MediatR.Tests/PipelineTests.cs
+++ b/test/MediatR.Tests/PipelineTests.cs
@@ -69,7 +69,7 @@ public class PipelineTests
             _output = output;
         }
 
-        public async Task<Pong> Handle(Ping request, CancellationToken cancellationToken, RequestHandlerDelegate<Pong> next)
+        public async Task<Pong> Handle(Ping request, RequestHandlerDelegate<Pong> next, CancellationToken cancellationToken)
         {
             _output.Messages.Add("Outer before");
             var response = await next();
@@ -88,7 +88,7 @@ public class PipelineTests
             _output = output;
         }
 
-        public async Task<Pong> Handle(Ping request, CancellationToken cancellationToken, RequestHandlerDelegate<Pong> next)
+        public async Task<Pong> Handle(Ping request, RequestHandlerDelegate<Pong> next, CancellationToken cancellationToken)
         {
             _output.Messages.Add("Inner before");
             var response = await next();
@@ -108,7 +108,7 @@ public class PipelineTests
             _output = output;
         }
 
-        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
         {
             _output.Messages.Add("Inner generic before");
             var response = await next();
@@ -128,7 +128,7 @@ public class PipelineTests
             _output = output;
         }
 
-        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
         {
             _output.Messages.Add("Outer generic before");
             var response = await next();
@@ -149,7 +149,7 @@ public class PipelineTests
             _output = output;
         }
 
-        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
         {
             _output.Messages.Add("Constrained before");
             var response = await next();
@@ -168,7 +168,7 @@ public class PipelineTests
             _output = output;
         }
 
-        public async Task<Pong> Handle(Ping request, CancellationToken cancellationToken, RequestHandlerDelegate<Pong> next)
+        public async Task<Pong> Handle(Ping request, RequestHandlerDelegate<Pong> next, CancellationToken cancellationToken)
         {
             _output.Messages.Add("Concrete before");
             var response = await next();

--- a/test/MediatR.Tests/StreamPipelineTests.cs
+++ b/test/MediatR.Tests/StreamPipelineTests.cs
@@ -72,7 +72,7 @@ public class StreamPipelineTests
             _output = output;
         }
 
-        public async IAsyncEnumerable<Pong> Handle(Ping request, [EnumeratorCancellation] CancellationToken cancellationToken, StreamHandlerDelegate<Pong> next)
+        public async IAsyncEnumerable<Pong> Handle(Ping request, StreamHandlerDelegate<Pong> next, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             _output.Messages.Add("Outer before");
             await foreach (var result in next())
@@ -92,7 +92,7 @@ public class StreamPipelineTests
             _output = output;
         }
 
-        public async IAsyncEnumerable<Pong> Handle(Ping request, [EnumeratorCancellation] CancellationToken cancellationToken, StreamHandlerDelegate<Pong> next)
+        public async IAsyncEnumerable<Pong> Handle(Ping request, StreamHandlerDelegate<Pong> next, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             _output.Messages.Add("Inner before");
             await foreach (var result in next())
@@ -113,7 +113,7 @@ public class StreamPipelineTests
             _output = output;
         }
 
-        public async IAsyncEnumerable<TResponse> Handle(TRequest request, [EnumeratorCancellation] CancellationToken cancellationToken, StreamHandlerDelegate<TResponse> next)
+        public async IAsyncEnumerable<TResponse> Handle(TRequest request, StreamHandlerDelegate<TResponse> next, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             _output.Messages.Add("Inner generic before");
             await foreach (var result in next())
@@ -134,7 +134,7 @@ public class StreamPipelineTests
             _output = output;
         }
 
-        public async IAsyncEnumerable<TResponse> Handle(TRequest request, [EnumeratorCancellation] CancellationToken cancellationToken, StreamHandlerDelegate<TResponse> next)
+        public async IAsyncEnumerable<TResponse> Handle(TRequest request, StreamHandlerDelegate<TResponse> next, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             _output.Messages.Add("Outer generic before");
             await foreach (var result in next())
@@ -155,7 +155,7 @@ public class StreamPipelineTests
         {
             _output = output;
         }
-        public async IAsyncEnumerable<TResponse> Handle(TRequest request, [EnumeratorCancellation] CancellationToken cancellationToken, StreamHandlerDelegate<TResponse> next)
+        public async IAsyncEnumerable<TResponse> Handle(TRequest request, StreamHandlerDelegate<TResponse> next, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             _output.Messages.Add("Constrained before");
             await foreach (var result in next())
@@ -175,7 +175,7 @@ public class StreamPipelineTests
             _output = output;
         }
 
-        public async IAsyncEnumerable<Pong> Handle(Ping request, [EnumeratorCancellation] CancellationToken cancellationToken, StreamHandlerDelegate<Pong> next)
+        public async IAsyncEnumerable<Pong> Handle(Ping request, StreamHandlerDelegate<Pong> next, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             _output.Messages.Add("Concrete before");
             await foreach (var result in next())


### PR DESCRIPTION
The code has been modified to follow the CA1068 rule, which indicates that the CancellationToken parameter must come last, while in some of MediatR methods the rule was followed, in many others it wasn't.

https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1068

The tests are also modified accordingly:

![image](https://user-images.githubusercontent.com/400362/183293040-fc181c81-00f5-4fcd-ac7c-ce9a9523fffb.png)

`Handle` and `Publish` now taking the `next` as a second param and the `cancelationToken` as the last param.

Although this pull request isn't backwards compatible, the modification isn't hard to implement, all it needs is to switch places between `next` and `cancelationToken` arguments.