### PR TITLE
Fixed Handle method parameters in IPipelineBehavior

### DIFF
--- a/samples/MediatR.Examples/GenericPipelineBehavior.cs
+++ b/samples/MediatR.Examples/GenericPipelineBehavior.cs
@@ -14,7 +14,7 @@ public class GenericPipelineBehavior<TRequest, TResponse> : IPipelineBehavior<TR
         _writer = writer;
     }
 
-    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
     {
         await _writer.WriteLineAsync("-- Handling Request");
         var response = await next();

--- a/src/MediatR/IPipelineBehavior.cs
+++ b/src/MediatR/IPipelineBehavior.cs
@@ -26,5 +26,5 @@ public interface IPipelineBehavior<in TRequest, TResponse> where TRequest : IReq
     /// <param name="next">Awaitable delegate for the next action in the pipeline. Eventually this delegate represents the handler.</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Awaitable task returning the <typeparamref name="TResponse"/></returns>
-    Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken);
+    Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next);
 }

--- a/src/MediatR/Pipeline/RequestExceptionActionProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestExceptionActionProcessorBehavior.cs
@@ -23,7 +23,7 @@ public class RequestExceptionActionProcessorBehavior<TRequest, TResponse> : IPip
 
     public RequestExceptionActionProcessorBehavior(ServiceFactory serviceFactory) => _serviceFactory = serviceFactory;
 
-    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
     {
         try
         {

--- a/src/MediatR/Pipeline/RequestExceptionProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestExceptionProcessorBehavior.cs
@@ -23,7 +23,7 @@ public class RequestExceptionProcessorBehavior<TRequest, TResponse> : IPipelineB
 
     public RequestExceptionProcessorBehavior(ServiceFactory serviceFactory) => _serviceFactory = serviceFactory;
 
-    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
     {
         try
         {

--- a/src/MediatR/Pipeline/RequestPostProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestPostProcessorBehavior.cs
@@ -17,7 +17,7 @@ public class RequestPostProcessorBehavior<TRequest, TResponse> : IPipelineBehavi
     public RequestPostProcessorBehavior(IEnumerable<IRequestPostProcessor<TRequest, TResponse>> postProcessors) 
         => _postProcessors = postProcessors;
 
-    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
     {
         var response = await next().ConfigureAwait(false);
 

--- a/src/MediatR/Pipeline/RequestPreProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestPreProcessorBehavior.cs
@@ -17,7 +17,7 @@ public class RequestPreProcessorBehavior<TRequest, TResponse> : IPipelineBehavio
     public RequestPreProcessorBehavior(IEnumerable<IRequestPreProcessor<TRequest>> preProcessors) 
         => _preProcessors = preProcessors;
 
-    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
     {
         foreach (var processor in _preProcessors)
         {

--- a/src/MediatR/Wrappers/RequestHandlerWrapper.cs
+++ b/src/MediatR/Wrappers/RequestHandlerWrapper.cs
@@ -32,6 +32,6 @@ public class RequestHandlerWrapperImpl<TRequest, TResponse> : RequestHandlerWrap
         return serviceFactory
             .GetInstances<IPipelineBehavior<TRequest, TResponse>>()
             .Reverse()
-            .Aggregate((RequestHandlerDelegate<TResponse>) Handler, (next, pipeline) => () => pipeline.Handle((TRequest)request, next, cancellationToken))();
+            .Aggregate((RequestHandlerDelegate<TResponse>) Handler, (next, pipeline) => () => pipeline.Handle((TRequest)request, cancellationToken, next))();
     }
 }

--- a/test/MediatR.Tests/PipelineTests.cs
+++ b/test/MediatR.Tests/PipelineTests.cs
@@ -69,7 +69,7 @@ public class PipelineTests
             _output = output;
         }
 
-        public async Task<Pong> Handle(Ping request, RequestHandlerDelegate<Pong> next, CancellationToken cancellationToken)
+        public async Task<Pong> Handle(Ping request, CancellationToken cancellationToken, RequestHandlerDelegate<Pong> next)
         {
             _output.Messages.Add("Outer before");
             var response = await next();
@@ -88,7 +88,7 @@ public class PipelineTests
             _output = output;
         }
 
-        public async Task<Pong> Handle(Ping request, RequestHandlerDelegate<Pong> next, CancellationToken cancellationToken)
+        public async Task<Pong> Handle(Ping request, CancellationToken cancellationToken, RequestHandlerDelegate<Pong> next)
         {
             _output.Messages.Add("Inner before");
             var response = await next();
@@ -108,7 +108,7 @@ public class PipelineTests
             _output = output;
         }
 
-        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
         {
             _output.Messages.Add("Inner generic before");
             var response = await next();
@@ -128,7 +128,7 @@ public class PipelineTests
             _output = output;
         }
 
-        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
         {
             _output.Messages.Add("Outer generic before");
             var response = await next();
@@ -149,7 +149,7 @@ public class PipelineTests
             _output = output;
         }
 
-        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
         {
             _output.Messages.Add("Constrained before");
             var response = await next();
@@ -168,7 +168,7 @@ public class PipelineTests
             _output = output;
         }
 
-        public async Task<Pong> Handle(Ping request, RequestHandlerDelegate<Pong> next, CancellationToken cancellationToken)
+        public async Task<Pong> Handle(Ping request, CancellationToken cancellationToken, RequestHandlerDelegate<Pong> next)
         {
             _output.Messages.Add("Concrete before");
             var response = await next();


### PR DESCRIPTION
There is a difference between the 10.0.1 version of the Handle method and the 11.0.0 version. Version updates require refactoring the code.