### PR TITLE
Adding type forwardings for types that were moved to the Contracts package

### DIFF
--- a/src/MediatR/TypeForwardings.cs
+++ b/src/MediatR/TypeForwardings.cs
@@ -1,0 +1,8 @@
+﻿using System.Runtime.CompilerServices;
+using MediatR;
+
+[assembly: TypeForwardedTo(typeof(IBaseRequest))]
+[assembly: TypeForwardedTo(typeof(IRequest<>))]
+[assembly: TypeForwardedTo(typeof(IRequest))]
+[assembly: TypeForwardedTo(typeof(INotification))]
+[assembly: TypeForwardedTo(typeof(Unit))]


### PR DESCRIPTION
This pull request is a proposal to solve the issue described in https://github.com/jbogard/MediatR/issues/692