### PR TITLE
Added static modifier for lambdas where applicable in Mediatr project.

### DIFF
--- a/src/MediatR/Internal/HandlersOrderer.cs
+++ b/src/MediatR/Internal/HandlersOrderer.cs
@@ -15,12 +15,12 @@ internal static class HandlersOrderer
         }
 
         var requestObjectDetails = new ObjectDetails(request);
-        var handlerObjectsDetails = handlers.Select(s => new ObjectDetails(s)).ToList();
+        var handlerObjectsDetails = handlers.Select(static s => new ObjectDetails(s)).ToList();
 
         var uniqueHandlers = RemoveOverridden(handlerObjectsDetails).ToArray();
         Array.Sort(uniqueHandlers, requestObjectDetails);
 
-        return uniqueHandlers.Select(s => s.Value).ToList();
+        return uniqueHandlers.Select(static s => s.Value).ToList();
     }
 
     private static IEnumerable<ObjectDetails> RemoveOverridden(IList<ObjectDetails> handlersData)
@@ -45,6 +45,6 @@ internal static class HandlersOrderer
             }
         }
 
-        return handlersData.Where(w => !w.IsOverridden);
+        return handlersData.Where(static w => !w.IsOverridden);
     }
 }

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -148,7 +148,7 @@ public class Mediator : IMediator
             {
                 var requestInterfaceType = requestTypeKey
                     .GetInterfaces()
-                    .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IStreamRequest<>));
+                    .FirstOrDefault(static i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IStreamRequest<>));
                 var isValidRequest = requestInterfaceType != null;
 
                 if (!isValidRequest)

--- a/src/MediatR/Pipeline/RequestExceptionActionProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestExceptionActionProcessorBehavior.cs
@@ -35,9 +35,9 @@ public class RequestExceptionActionProcessorBehavior<TRequest, TResponse> : IPip
 
             var actionsForException = exceptionTypes
                 .SelectMany(exceptionType => GetActionsForException(exceptionType, request))
-                .GroupBy(actionForException => actionForException.Action.GetType())
-                .Select(actionForException => actionForException.First())
-                .Select(actionForException => (MethodInfo: GetMethodInfoForAction(actionForException.ExceptionType), actionForException.Action))
+                .GroupBy(static actionForException => actionForException.Action.GetType())
+                .Select(static actionForException => actionForException.First())
+                .Select(static actionForException => (MethodInfo: GetMethodInfoForAction(actionForException.ExceptionType), actionForException.Action))
                 .ToList();
 
             foreach (var actionForException in actionsForException)

--- a/src/MediatR/Pipeline/RequestExceptionProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestExceptionProcessorBehavior.cs
@@ -37,9 +37,9 @@ public class RequestExceptionProcessorBehavior<TRequest, TResponse> : IPipelineB
 
             var handlersForException = exceptionTypes
                 .SelectMany(exceptionType => GetHandlersForException(exceptionType, request))
-                .GroupBy(handlerForException => handlerForException.Handler.GetType())
-                .Select(handlerForException => handlerForException.First())
-                .Select(handlerForException => (MethodInfo: GetMethodInfoForHandler(handlerForException.ExceptionType), handlerForException.Handler))
+                .GroupBy(static handlerForException => handlerForException.Handler.GetType())
+                .Select(static handlerForException => handlerForException.First())
+                .Select(static handlerForException => (MethodInfo: GetMethodInfoForHandler(handlerForException.ExceptionType), handlerForException.Handler))
                 .ToList();
 
             foreach (var handlerForException in handlersForException)

--- a/src/MediatR/Wrappers/NotificationHandlerWrapper.cs
+++ b/src/MediatR/Wrappers/NotificationHandlerWrapper.cs
@@ -22,7 +22,7 @@ public class NotificationHandlerWrapperImpl<TNotification> : NotificationHandler
     {
         var handlers = serviceFactory
             .GetInstances<INotificationHandler<TNotification>>()
-            .Select(x => new Func<INotification, CancellationToken, Task>((theNotification, theToken) => x.Handle((TNotification)theNotification, theToken)));
+            .Select(static x => new Func<INotification, CancellationToken, Task>((theNotification, theToken) => x.Handle((TNotification)theNotification, theToken)));
 
         return publish(handlers, notification, cancellationToken);
     }


### PR DESCRIPTION
I've gone through the project and I believe I've added the `static` modifier to all lambdas where it is possible, with the goal of avoiding unnecessary allocations.