### PR TITLE
feat (Nuget): Add project Url and LicenseUrl

### DIFF
--- a/src/MediatR.Contracts/MediatR.Contracts.csproj
+++ b/src/MediatR.Contracts/MediatR.Contracts.csproj
@@ -13,6 +13,8 @@
     <AssemblyOriginatorKeyFile>..\..\MediatR.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageIcon>gradient_128x128.png</PackageIcon>
+    <PackageProjectUrl>https://github.com/jbogard/MediatR/</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/jbogard/MediatR/blob/master/LICENSE</PackageLicenseUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/MediatR/MediatR.csproj
+++ b/src/MediatR/MediatR.csproj
@@ -12,6 +12,8 @@
     <AssemblyOriginatorKeyFile>..\..\MediatR.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageIcon>gradient_128x128.png</PackageIcon>
+    <PackageProjectUrl>https://github.com/jbogard/MediatR/</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/jbogard/MediatR/blob/master/LICENSE</PackageLicenseUrl>
     <MinVerTagPrefix>v</MinVerTagPrefix>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
Add the `ProjectUrl` and `LicenseUrl` so they are exposed in Nuget browsers.