### PR TITLE
Consolidate registration to single configuration object and optimize registration

### DIFF
--- a/samples/MediatR.Examples.AspNetCore/Program.cs
+++ b/samples/MediatR.Examples.AspNetCore/Program.cs
@@ -24,7 +24,7 @@ public static class Program
 
         services.AddMediatR(cfg =>
         {
-            cfg.RegisterHandlersFromAssemblies(typeof(Ping).Assembly, typeof(Sing).Assembly);
+            cfg.RegisterServicesFromAssemblies(typeof(Ping).Assembly, typeof(Sing).Assembly);
         });
 
         services.AddScoped(typeof(IStreamRequestHandler<Sing, Song>), typeof(SingHandler));

--- a/samples/MediatR.Examples.AspNetCore/Program.cs
+++ b/samples/MediatR.Examples.AspNetCore/Program.cs
@@ -22,7 +22,10 @@ public static class Program
 
         services.AddSingleton<TextWriter>(writer);
 
-        services.AddMediatR(typeof(Ping), typeof(Sing));
+        services.AddMediatR(cfg =>
+        {
+            cfg.RegisterHandlersFromAssemblies(typeof(Ping).Assembly, typeof(Sing).Assembly);
+        });
 
         services.AddScoped(typeof(IStreamRequestHandler<Sing, Song>), typeof(SingHandler));
 

--- a/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
+++ b/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
@@ -12,24 +12,52 @@ public class MediatRServiceConfiguration
     public ServiceLifetime Lifetime { get; set; } = ServiceLifetime.Transient;
     public RequestExceptionActionProcessorStrategy RequestExceptionActionProcessorStrategy { get; set; }
         = RequestExceptionActionProcessorStrategy.ApplyForUnhandledExceptions;
+
     internal List<Assembly> AssembliesToRegister { get; } = new();
 
-    public MediatRServiceConfiguration RegisterHandlersFromAssemblyContaining<T>() 
-        => RegisterHandlersFromAssemblyContaining(typeof(T));
+    public List<ServiceDescriptor> BehaviorsToRegister { get; } = new();
 
-    public MediatRServiceConfiguration RegisterHandlersFromAssemblyContaining(Type type) 
-        => RegisterHandlersFromAssembly(type.Assembly);
+    public MediatRServiceConfiguration RegisterServicesFromAssemblyContaining<T>()
+        => RegisterServicesFromAssemblyContaining(typeof(T));
 
-    public MediatRServiceConfiguration RegisterHandlersFromAssembly(Assembly assembly)
+    public MediatRServiceConfiguration RegisterServicesFromAssemblyContaining(Type type)
+        => RegisterServicesFromAssembly(type.Assembly);
+
+    public MediatRServiceConfiguration RegisterServicesFromAssembly(Assembly assembly)
     {
         AssembliesToRegister.Add(assembly);
+
         return this;
     }
 
-    public MediatRServiceConfiguration RegisterHandlersFromAssemblies(
+    public MediatRServiceConfiguration RegisterServicesFromAssemblies(
         params Assembly[] assemblies)
     {
         AssembliesToRegister.AddRange(assemblies);
+
+        return this;
+    }
+
+    public MediatRServiceConfiguration AddBehavior<TServiceType, TImplementationType>(
+        ServiceLifetime serviceLifetime = ServiceLifetime.Transient) =>
+        AddBehavior(typeof(TServiceType), typeof(TImplementationType), serviceLifetime);
+
+    public MediatRServiceConfiguration AddBehavior(
+        Type serviceType,
+        Type implementationType,
+        ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
+    {
+        BehaviorsToRegister.Add(new ServiceDescriptor(serviceType, implementationType, serviceLifetime));
+
+        return this;
+    }
+
+    public MediatRServiceConfiguration AddOpenBehavior(Type openBehaviorType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
+    {
+        var serviceType = typeof(IPipelineBehavior<,>);
+
+        BehaviorsToRegister.Add(new ServiceDescriptor(serviceType, openBehaviorType, serviceLifetime));
+
         return this;
     }
 }

--- a/src/MediatR/MicrosoftExtensionsDI/ServiceCollectionExtensions.cs
+++ b/src/MediatR/MicrosoftExtensionsDI/ServiceCollectionExtensions.cs
@@ -37,9 +37,9 @@ public static class ServiceCollectionExtensions
             throw new ArgumentException("No assemblies found to scan. Supply at least one assembly to scan for handlers.");
         }
 
-        ServiceRegistrar.AddRequiredServices(services, serviceConfig);
-
         ServiceRegistrar.AddMediatRClasses(services, serviceConfig);
+
+        ServiceRegistrar.AddRequiredServices(services, serviceConfig);
 
         return services;
     }

--- a/src/MediatR/MicrosoftExtensionsDI/ServiceCollectionExtensions.cs
+++ b/src/MediatR/MicrosoftExtensionsDI/ServiceCollectionExtensions.cs
@@ -23,71 +23,24 @@ public static class ServiceCollectionExtensions
     /// Registers handlers and mediator types from the specified assemblies
     /// </summary>
     /// <param name="services">Service collection</param>
-    /// <param name="assemblies">Assemblies to scan</param>        
-    /// <returns>Service collection</returns>
-    public static IServiceCollection AddMediatR(this IServiceCollection services, params Assembly[] assemblies)
-        => services.AddMediatR(assemblies, configuration: null);
-
-    /// <summary>
-    /// Registers handlers and mediator types from the specified assemblies
-    /// </summary>
-    /// <param name="services">Service collection</param>
-    /// <param name="assemblies">Assemblies to scan</param>
     /// <param name="configuration">The action used to configure the options</param>
     /// <returns>Service collection</returns>
-    public static IServiceCollection AddMediatR(this IServiceCollection services, Action<MediatRServiceConfiguration>? configuration, params Assembly[] assemblies)
-        => services.AddMediatR(assemblies, configuration);
-
-    /// <summary>
-    /// Registers handlers and mediator types from the specified assemblies
-    /// </summary>
-    /// <param name="services">Service collection</param>
-    /// <param name="assemblies">Assemblies to scan</param>
-    /// <param name="configuration">The action used to configure the options</param>
-    /// <returns>Service collection</returns>
-    public static IServiceCollection AddMediatR(this IServiceCollection services, IEnumerable<Assembly> assemblies, Action<MediatRServiceConfiguration>? configuration)
+    public static IServiceCollection AddMediatR(this IServiceCollection services, 
+        Action<MediatRServiceConfiguration> configuration)
     {
-        if (!assemblies.Any())
+        var serviceConfig = new MediatRServiceConfiguration();
+
+        configuration.Invoke(serviceConfig);
+
+        if (!serviceConfig.AssembliesToRegister.Any())
         {
             throw new ArgumentException("No assemblies found to scan. Supply at least one assembly to scan for handlers.");
         }
-        var serviceConfig = new MediatRServiceConfiguration();
-
-        configuration?.Invoke(serviceConfig);
 
         ServiceRegistrar.AddRequiredServices(services, serviceConfig);
 
-        ServiceRegistrar.AddMediatRClasses(services, assemblies, serviceConfig);
+        ServiceRegistrar.AddMediatRClasses(services, serviceConfig);
 
         return services;
     }
-
-    /// <summary>
-    /// Registers handlers and mediator types from the assemblies that contain the specified types
-    /// </summary>
-    /// <param name="services"></param>
-    /// <param name="handlerAssemblyMarkerTypes"></param>        
-    /// <returns>Service collection</returns>
-    public static IServiceCollection AddMediatR(this IServiceCollection services, params Type[] handlerAssemblyMarkerTypes)
-        => services.AddMediatR(handlerAssemblyMarkerTypes, configuration: null);
-        
-    /// <summary>
-    /// Registers handlers and mediator types from the assemblies that contain the specified types
-    /// </summary>
-    /// <param name="services"></param>
-    /// <param name="handlerAssemblyMarkerTypes"></param>
-    /// <param name="configuration">The action used to configure the options</param>
-    /// <returns>Service collection</returns>
-    public static IServiceCollection AddMediatR(this IServiceCollection services, Action<MediatRServiceConfiguration>? configuration, params Type[] handlerAssemblyMarkerTypes)
-        => services.AddMediatR(handlerAssemblyMarkerTypes, configuration);
-
-    /// <summary>
-    /// Registers handlers and mediator types from the assemblies that contain the specified types
-    /// </summary>
-    /// <param name="services"></param>
-    /// <param name="handlerAssemblyMarkerTypes"></param>
-    /// <param name="configuration">The action used to configure the options</param>
-    /// <returns>Service collection</returns>
-    public static IServiceCollection AddMediatR(this IServiceCollection services, IEnumerable<Type> handlerAssemblyMarkerTypes, Action<MediatRServiceConfiguration>? configuration)
-        => services.AddMediatR(handlerAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly), configuration);
 }

--- a/src/MediatR/Pipeline/RequestExceptionHandlerState.cs
+++ b/src/MediatR/Pipeline/RequestExceptionHandlerState.cs
@@ -14,7 +14,7 @@ public class RequestExceptionHandlerState<TResponse>
     public bool Handled { get; private set; }
 
     /// <summary>
-    /// The response that is returned if <see cref="Handled"/> is  <code>true</code>.
+    /// The response that is returned if <see cref="Handled"/> is <code>true</code>.
     /// </summary>
     public TResponse? Response { get; private set; }
 

--- a/src/MediatR/Registration/ServiceRegistrar.cs
+++ b/src/MediatR/Registration/ServiceRegistrar.cs
@@ -10,9 +10,9 @@ namespace MediatR.Registration;
 
 public static class ServiceRegistrar
 {
-    public static void AddMediatRClasses(IServiceCollection services, IEnumerable<Assembly> assembliesToScan, MediatRServiceConfiguration configuration)
+    public static void AddMediatRClasses(IServiceCollection services, MediatRServiceConfiguration configuration)
     {
-        assembliesToScan = assembliesToScan.Distinct().ToArray();
+        var assembliesToScan = configuration.AssembliesToRegister.Distinct().ToArray();
 
         ConnectImplementationsToTypesClosing(typeof(IRequestHandler<,>), services, assembliesToScan, false, configuration);
         ConnectImplementationsToTypesClosing(typeof(INotificationHandler<>), services, assembliesToScan, true, configuration);

--- a/test/MediatR.Benchmarks/Benchmarks.cs
+++ b/test/MediatR.Benchmarks/Benchmarks.cs
@@ -20,7 +20,7 @@ namespace MediatR.Benchmarks
 
             services.AddSingleton(TextWriter.Null);
 
-            services.AddMediatR(cfg => cfg.RegisterHandlersFromAssemblyContaining(typeof(Ping)));
+            services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining(typeof(Ping)));
 
             services.AddScoped(typeof(IPipelineBehavior<,>), typeof(GenericPipelineBehavior<,>));
             services.AddScoped(typeof(IRequestPreProcessor<>), typeof(GenericRequestPreProcessor<>));

--- a/test/MediatR.Benchmarks/Benchmarks.cs
+++ b/test/MediatR.Benchmarks/Benchmarks.cs
@@ -20,7 +20,7 @@ namespace MediatR.Benchmarks
 
             services.AddSingleton(TextWriter.Null);
 
-            services.AddMediatR(typeof(Ping));
+            services.AddMediatR(cfg => cfg.RegisterHandlersFromAssemblyContaining(typeof(Ping)));
 
             services.AddScoped(typeof(IPipelineBehavior<,>), typeof(GenericPipelineBehavior<,>));
             services.AddScoped(typeof(IRequestPreProcessor<>), typeof(GenericRequestPreProcessor<>));

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/AssemblyResolutionTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/AssemblyResolutionTests.cs
@@ -16,7 +16,7 @@ public class AssemblyResolutionTests
     {
         IServiceCollection services = new ServiceCollection();
         services.AddSingleton(new Logger());
-        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssembly(typeof(Ping).Assembly));
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(Ping).Assembly));
         _provider = services.BuildServiceProvider();
     }
 

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/AssemblyResolutionTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/AssemblyResolutionTests.cs
@@ -16,7 +16,7 @@ public class AssemblyResolutionTests
     {
         IServiceCollection services = new ServiceCollection();
         services.AddSingleton(new Logger());
-        services.AddMediatR(typeof(Ping).GetTypeInfo().Assembly);
+        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssembly(typeof(Ping).Assembly));
         _provider = services.BuildServiceProvider();
     }
 
@@ -55,7 +55,7 @@ public class AssemblyResolutionTests
     {
         var services = new ServiceCollection();
 
-        Action registration = () => services.AddMediatR(new Type[0]);
+        Action registration = () => services.AddMediatR(_ => {});
 
         registration.ShouldThrow<ArgumentException>();
     }

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/CustomMediatorTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/CustomMediatorTests.cs
@@ -15,7 +15,11 @@ public class CustomMediatorTests
     {
         IServiceCollection services = new ServiceCollection();
         services.AddSingleton(new Logger());
-        services.AddMediatR(cfg => cfg.Using<MyCustomMediator>(), typeof(CustomMediatorTests));
+        services.AddMediatR(cfg =>
+        {
+            cfg.MediatorImplementationType = typeof(MyCustomMediator);
+            cfg.RegisterHandlersFromAssemblyContaining(typeof(CustomMediatorTests));
+        });
         _provider = services.BuildServiceProvider();
     }
 
@@ -43,10 +47,14 @@ public class CustomMediatorTests
     {
         IServiceCollection services = new ServiceCollection();
         services.AddSingleton(new Logger());
-        services.AddMediatR(cfg => cfg.Using<MyCustomMediator>(), typeof(CustomMediatorTests));
+        services.AddMediatR(cfg =>
+        {
+            cfg.MediatorImplementationType = typeof(MyCustomMediator);
+            cfg.RegisterHandlersFromAssemblyContaining(typeof(CustomMediatorTests));
+        });
             
         // Call AddMediatr again, this should NOT override our custom mediatr (With MS DI, last registration wins)
-        services.AddMediatR(typeof(CustomMediatorTests));
+        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssemblyContaining(typeof(CustomMediatorTests)));
 
         var provider = services.BuildServiceProvider();
         var mediator = provider.GetRequiredService<IMediator>();

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/CustomMediatorTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/CustomMediatorTests.cs
@@ -18,7 +18,7 @@ public class CustomMediatorTests
         services.AddMediatR(cfg =>
         {
             cfg.MediatorImplementationType = typeof(MyCustomMediator);
-            cfg.RegisterHandlersFromAssemblyContaining(typeof(CustomMediatorTests));
+            cfg.RegisterServicesFromAssemblyContaining(typeof(CustomMediatorTests));
         });
         _provider = services.BuildServiceProvider();
     }
@@ -50,11 +50,11 @@ public class CustomMediatorTests
         services.AddMediatR(cfg =>
         {
             cfg.MediatorImplementationType = typeof(MyCustomMediator);
-            cfg.RegisterHandlersFromAssemblyContaining(typeof(CustomMediatorTests));
+            cfg.RegisterServicesFromAssemblyContaining(typeof(CustomMediatorTests));
         });
             
         // Call AddMediatr again, this should NOT override our custom mediatr (With MS DI, last registration wins)
-        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssemblyContaining(typeof(CustomMediatorTests)));
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining(typeof(CustomMediatorTests)));
 
         var provider = services.BuildServiceProvider();
         var mediator = provider.GetRequiredService<IMediator>();

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/DerivingRequestsTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/DerivingRequestsTests.cs
@@ -15,7 +15,7 @@ public class DerivingRequestsTests
     {
         IServiceCollection services = new ServiceCollection();
         services.AddSingleton(new Logger());
-        services.AddMediatR(typeof(Ping));
+        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssemblyContaining(typeof(Ping)));
         _provider = services.BuildServiceProvider();
         _mediator = _provider.GetRequiredService<IMediator>();
     }

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/DerivingRequestsTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/DerivingRequestsTests.cs
@@ -15,7 +15,7 @@ public class DerivingRequestsTests
     {
         IServiceCollection services = new ServiceCollection();
         services.AddSingleton(new Logger());
-        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssemblyContaining(typeof(Ping)));
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining(typeof(Ping)));
         _provider = services.BuildServiceProvider();
         _mediator = _provider.GetRequiredService<IMediator>();
     }

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/DuplicateAssemblyResolutionTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/DuplicateAssemblyResolutionTests.cs
@@ -15,7 +15,7 @@ public class DuplicateAssemblyResolutionTests
     {
         IServiceCollection services = new ServiceCollection();
         services.AddSingleton(new Logger());
-        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssemblies(typeof(Ping).Assembly, typeof(Ping).Assembly));
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(typeof(Ping).Assembly, typeof(Ping).Assembly));
         _provider = services.BuildServiceProvider();
     }
 

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/DuplicateAssemblyResolutionTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/DuplicateAssemblyResolutionTests.cs
@@ -15,7 +15,7 @@ public class DuplicateAssemblyResolutionTests
     {
         IServiceCollection services = new ServiceCollection();
         services.AddSingleton(new Logger());
-        services.AddMediatR(typeof(Ping), typeof(Ping));
+        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssemblies(typeof(Ping).Assembly, typeof(Ping).Assembly));
         _provider = services.BuildServiceProvider();
     }
 

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/PipeLineMultiCallToConstructorTest.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/PipeLineMultiCallToConstructorTest.cs
@@ -81,7 +81,7 @@ public class PipelineMultiCallToConstructorTests
 
         services.AddSingleton(output);
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ConstructorTestBehavior<,>));
-        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssembly(typeof(Ping).Assembly));
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(Ping).Assembly));
         var provider = services.BuildServiceProvider();
 
         var mediator = provider.GetRequiredService<IMediator>();

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/PipeLineMultiCallToConstructorTest.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/PipeLineMultiCallToConstructorTest.cs
@@ -81,7 +81,7 @@ public class PipelineMultiCallToConstructorTests
 
         services.AddSingleton(output);
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ConstructorTestBehavior<,>));
-        services.AddMediatR(typeof(Ping).GetTypeInfo().Assembly);
+        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssembly(typeof(Ping).Assembly));
         var provider = services.BuildServiceProvider();
 
         var mediator = provider.GetRequiredService<IMediator>();

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/PipelineTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/PipelineTests.cs
@@ -323,7 +323,7 @@ public class PipelineTests
         services.AddSingleton(output);
         services.AddTransient<IPipelineBehavior<Ping, Pong>, OuterBehavior>();
         services.AddTransient<IPipelineBehavior<Ping, Pong>, InnerBehavior>();
-        services.AddMediatR(typeof(Ping).GetTypeInfo().Assembly);
+        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssembly(typeof(Ping).Assembly));
         var provider = services.BuildServiceProvider();
 
         var mediator = provider.GetRequiredService<IMediator>();
@@ -359,7 +359,7 @@ public class PipelineTests
         services.AddSingleton(output);
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(OuterBehavior<,>));
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(InnerBehavior<,>));
-        services.AddMediatR(typeof(Ping).GetTypeInfo().Assembly);
+        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssembly(typeof(Ping).Assembly));
         var provider = services.BuildServiceProvider();
 
         var mediator = provider.GetRequiredService<IMediator>();
@@ -392,7 +392,7 @@ public class PipelineTests
         var output = new Logger();
         IServiceCollection services = new ServiceCollection();
         services.AddSingleton(output);
-        services.AddMediatR(typeof(Ping).GetTypeInfo().Assembly);
+        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssembly(typeof(Ping).Assembly));
         var provider = services.BuildServiceProvider();
 
         var mediator = provider.GetRequiredService<IMediator>();
@@ -421,7 +421,7 @@ public class PipelineTests
         var output = new Logger();
         IServiceCollection services = new ServiceCollection();
         services.AddSingleton(output);
-        services.AddMediatR(typeof(Ping).GetTypeInfo().Assembly);
+        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssembly(typeof(Ping).Assembly));
         var provider = services.BuildServiceProvider();
 
         var mediator = provider.GetRequiredService<IMediator>();
@@ -438,7 +438,7 @@ public class PipelineTests
         var output = new Logger();
         IServiceCollection services = new ServiceCollection();
         services.AddSingleton(output);
-        services.AddMediatR(typeof(Ping).GetTypeInfo().Assembly);
+        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssembly(typeof(Ping).Assembly));
         var provider = services.BuildServiceProvider();
 
         var mediator = provider.GetRequiredService<IMediator>();
@@ -455,7 +455,7 @@ public class PipelineTests
         var output = new Logger();
         IServiceCollection services = new ServiceCollection();
         services.AddSingleton(output);
-        services.AddMediatR(typeof(Ping).GetTypeInfo().Assembly);
+        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssembly(typeof(Ping).Assembly));
         var provider = services.BuildServiceProvider();
 
         var mediator = provider.GetRequiredService<IMediator>();
@@ -475,7 +475,7 @@ public class PipelineTests
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(OuterBehavior<,>));
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(InnerBehavior<,>));
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ConstrainedBehavior<,>));
-        services.AddMediatR(typeof(Ping).GetTypeInfo().Assembly);
+        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssembly(typeof(Ping).Assembly));
         var provider = services.BuildServiceProvider();
 
         var mediator = provider.GetRequiredService<IMediator>();

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/PipelineTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/PipelineTests.cs
@@ -323,7 +323,7 @@ public class PipelineTests
         services.AddSingleton(output);
         services.AddTransient<IPipelineBehavior<Ping, Pong>, OuterBehavior>();
         services.AddTransient<IPipelineBehavior<Ping, Pong>, InnerBehavior>();
-        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssembly(typeof(Ping).Assembly));
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(Ping).Assembly));
         var provider = services.BuildServiceProvider();
 
         var mediator = provider.GetRequiredService<IMediator>();
@@ -357,9 +357,12 @@ public class PipelineTests
         var output = new Logger();
         IServiceCollection services = new ServiceCollection();
         services.AddSingleton(output);
-        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(OuterBehavior<,>));
-        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(InnerBehavior<,>));
-        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssembly(typeof(Ping).Assembly));
+        services.AddMediatR(cfg =>
+        {
+            cfg.AddOpenBehavior(typeof(OuterBehavior<,>));
+            cfg.AddOpenBehavior(typeof(InnerBehavior<,>));
+            cfg.RegisterServicesFromAssembly(typeof(Ping).Assembly);
+        });
         var provider = services.BuildServiceProvider();
 
         var mediator = provider.GetRequiredService<IMediator>();
@@ -392,7 +395,7 @@ public class PipelineTests
         var output = new Logger();
         IServiceCollection services = new ServiceCollection();
         services.AddSingleton(output);
-        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssembly(typeof(Ping).Assembly));
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(Ping).Assembly));
         var provider = services.BuildServiceProvider();
 
         var mediator = provider.GetRequiredService<IMediator>();
@@ -421,7 +424,7 @@ public class PipelineTests
         var output = new Logger();
         IServiceCollection services = new ServiceCollection();
         services.AddSingleton(output);
-        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssembly(typeof(Ping).Assembly));
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(Ping).Assembly));
         var provider = services.BuildServiceProvider();
 
         var mediator = provider.GetRequiredService<IMediator>();
@@ -438,7 +441,7 @@ public class PipelineTests
         var output = new Logger();
         IServiceCollection services = new ServiceCollection();
         services.AddSingleton(output);
-        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssembly(typeof(Ping).Assembly));
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(Ping).Assembly));
         var provider = services.BuildServiceProvider();
 
         var mediator = provider.GetRequiredService<IMediator>();
@@ -455,7 +458,7 @@ public class PipelineTests
         var output = new Logger();
         IServiceCollection services = new ServiceCollection();
         services.AddSingleton(output);
-        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssembly(typeof(Ping).Assembly));
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(Ping).Assembly));
         var provider = services.BuildServiceProvider();
 
         var mediator = provider.GetRequiredService<IMediator>();
@@ -475,7 +478,7 @@ public class PipelineTests
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(OuterBehavior<,>));
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(InnerBehavior<,>));
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ConstrainedBehavior<,>));
-        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssembly(typeof(Ping).Assembly));
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(Ping).Assembly));
         var provider = services.BuildServiceProvider();
 
         var mediator = provider.GetRequiredService<IMediator>();

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/StreamPipelineTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/StreamPipelineTests.cs
@@ -63,7 +63,7 @@ public class StreamPipelineTests
         services.AddSingleton(output);
         services.AddTransient<IStreamPipelineBehavior<StreamPing, Pong>, OuterBehavior>();
         services.AddTransient<IStreamPipelineBehavior<StreamPing, Pong>, InnerBehavior>();
-        services.AddMediatR(typeof(Ping).GetTypeInfo().Assembly);
+        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssembly(typeof(Ping).Assembly));
         var provider = services.BuildServiceProvider();
 
         var mediator = provider.GetRequiredService<IMediator>();

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/StreamPipelineTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/StreamPipelineTests.cs
@@ -63,7 +63,7 @@ public class StreamPipelineTests
         services.AddSingleton(output);
         services.AddTransient<IStreamPipelineBehavior<StreamPing, Pong>, OuterBehavior>();
         services.AddTransient<IStreamPipelineBehavior<StreamPing, Pong>, InnerBehavior>();
-        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssembly(typeof(Ping).Assembly));
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(Ping).Assembly));
         var provider = services.BuildServiceProvider();
 
         var mediator = provider.GetRequiredService<IMediator>();

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/TypeEvaluatorTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/TypeEvaluatorTests.cs
@@ -16,9 +16,10 @@ public class TypeEvaluatorTests
     {
         IServiceCollection services = new ServiceCollection();
         services.AddSingleton(new Logger());
-        services.AddMediatR(new[] { typeof(Ping).GetTypeInfo().Assembly }, cfg =>
+        services.AddMediatR(cfg =>
         {
-            cfg.WithEvaluator(t => t.Namespace == "MediatR.Extensions.Microsoft.DependencyInjection.Tests.Included");
+            cfg.RegisterHandlersFromAssemblyContaining(typeof(Ping));
+            cfg.TypeEvaluator = t => t.Namespace == "MediatR.Extensions.Microsoft.DependencyInjection.Tests.Included";
         });
         _provider = services.BuildServiceProvider();
     }

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/TypeEvaluatorTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/TypeEvaluatorTests.cs
@@ -1,27 +1,30 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace MediatR.Extensions.Microsoft.DependencyInjection.Tests;
 
-using MediatR.Extensions.Microsoft.DependencyInjection.Tests.Included;
+using Included;
+using MediatR.Pipeline;
 using Shouldly;
 using System;
-using System.Reflection;
 using Xunit;
 
 public class TypeEvaluatorTests
 {
     private readonly IServiceProvider _provider;
+    private readonly IServiceCollection _services;
+
 
     public TypeEvaluatorTests()
     {
-        IServiceCollection services = new ServiceCollection();
-        services.AddSingleton(new Logger());
-        services.AddMediatR(cfg =>
+        _services = new ServiceCollection();
+        _services.AddSingleton(new Logger());
+        _services.AddMediatR(cfg =>
         {
-            cfg.RegisterHandlersFromAssemblyContaining(typeof(Ping));
+            cfg.RegisterServicesFromAssemblyContaining(typeof(Ping));
             cfg.TypeEvaluator = t => t.Namespace == "MediatR.Extensions.Microsoft.DependencyInjection.Tests.Included";
         });
-        _provider = services.BuildServiceProvider();
+        _provider = _services.BuildServiceProvider();
     }
 
     [Fact]
@@ -35,5 +38,18 @@ public class TypeEvaluatorTests
     {
         _provider.GetService<IRequestHandler<Foo, Bar>>().ShouldNotBeNull();
         _provider.GetService<IRequestHandler<Ping, Pong>>().ShouldBeNull();
+    }
+
+    [Fact]
+    public void ShouldNotRegisterUnNeededBehaviors()
+    {
+        _services.Any(service => service.ImplementationType == typeof(RequestPreProcessorBehavior<,>))
+            .ShouldBeFalse();
+        _services.Any(service => service.ImplementationType == typeof(RequestPostProcessorBehavior<,>))
+            .ShouldBeFalse();
+        _services.Any(service => service.ImplementationType == typeof(RequestExceptionActionProcessorBehavior<,>))
+            .ShouldBeFalse();
+        _services.Any(service => service.ImplementationType == typeof(RequestExceptionProcessorBehavior<,>))
+            .ShouldBeFalse();
     }
 }

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/TypeResolutionTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/TypeResolutionTests.cs
@@ -16,7 +16,7 @@ public class TypeResolutionTests
     {
         IServiceCollection services = new ServiceCollection();
         services.AddSingleton(new Logger());
-        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssemblyContaining(typeof(Ping)));
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining(typeof(Ping)));
         _provider = services.BuildServiceProvider();
     }
 

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/TypeResolutionTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/TypeResolutionTests.cs
@@ -16,7 +16,7 @@ public class TypeResolutionTests
     {
         IServiceCollection services = new ServiceCollection();
         services.AddSingleton(new Logger());
-        services.AddMediatR(typeof(Ping));
+        services.AddMediatR(cfg => cfg.RegisterHandlersFromAssemblyContaining(typeof(Ping)));
         _provider = services.BuildServiceProvider();
     }
 


### PR DESCRIPTION
Consolidates registration and scanning into a single configuration object; Only registers extra behaviors (pre/post processor, etc.) if there are any available.

### API changes

All configuration would be consolidated into a single method (instead of parameters in an overload):

```diff
public static class ServiceCollectionExtensions {
-    public static IServiceCollection AddMediatR(this IServiceCollection services, params Assembly[] assemblies)
-    public static IServiceCollection AddMediatR(this IServiceCollection services, Action<MediatRServiceConfiguration>? configuration, params Assembly[] assemblies)
-    public static IServiceCollection AddMediatR(this IServiceCollection services, IEnumerable<Assembly> assemblies, Action<MediatRServiceConfiguration>? configuration)
-    public static IServiceCollection AddMediatR(this IServiceCollection services, params Type[] handlerAssemblyMarkerTypes)
-    public static IServiceCollection AddMediatR(this IServiceCollection services, Action<MediatRServiceConfiguration>? configuration, params Type[] handlerAssemblyMarkerTypes)
-    public static IServiceCollection AddMediatR(this IServiceCollection services, IEnumerable<Type> handlerAssemblyMarkerTypes, Action<MediatRServiceConfiguration>? configuration)
+    public static IServiceCollection AddMediatR(this IServiceCollection services, Action<MediatRServiceConfiguration> configuration)
}
```

All the parameters are now moved to the `MediatRServiceConfiguration` object, including a pass-through method to add behaviors:

```diff
public class MediatRServiceConfiguration {
-    public Func<Type, bool> TypeEvaluator { get; private set; } = t => true;
-    public Type MediatorImplementationType { get; private set; }
-    public ServiceLifetime Lifetime { get; private set; }
+    public Func<Type, bool> TypeEvaluator { get; set; } = t => true;
+    public Type MediatorImplementationType { get; set; } = typeof(Mediator);
+    public ServiceLifetime Lifetime { get; set; } = ServiceLifetime.Transient;
+    public RequestExceptionActionProcessorStrategy RequestExceptionActionProcessorStrategy { get; set; } = RequestExceptionActionProcessorStrategy.ApplyForUnhandledExceptions;
+    internal List<Assembly> AssembliesToRegister { get; } = new();
+    public List<ServiceDescriptor> BehaviorsToRegister { get; } = new();

// These methods removed to instead use the properties directly
-    public MediatRServiceConfiguration Using<TMediator>() where TMediator : IMediator
-    public MediatRServiceConfiguration AsSingleton()
-    public MediatRServiceConfiguration AsScoped()
-    public MediatRServiceConfiguration AsTransient()
-    public MediatRServiceConfiguration WithEvaluator(Func<Type, bool> evaluator)

// These replace the overloads for passing in types or assemblies to scan
+    public MediatRServiceConfiguration RegisterServicesFromAssemblyContaining<T>()
+    public MediatRServiceConfiguration RegisterServicesFromAssemblyContaining(Type type)
+    public MediatRServiceConfiguration RegisterServicesFromAssembly(Assembly assembly)
+    public MediatRServiceConfiguration RegisterServicesFromAssemblies(params Assembly[] assemblies)

// These are new methods to add concrete behaviors but merely passthrough the configuration to the underlying `IServiceCollection`
+    public MediatRServiceConfiguration AddBehavior<TServiceType, TImplementationType>(ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
+    public MediatRServiceConfiguration AddBehavior(Type serviceType, Type implementationType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
// This method is for registering an open behavior still passing through the configuration
+    public MediatRServiceConfiguration AddOpenBehavior(Type openBehaviorType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
```

### Behavior changes

The service scanning was modified to only register with the container the "built-in" behaviors of:
- `RequestPreProcessorBehavior<,>`
- `RequestPostProcessorBehavior<,>`
- `RequestExceptionProcessorBehavior<,>`
- `RequestExceptionActionProcessorBehavior<,>`
When "Sub-behaviors" of those types are found in the `IServiceCollection`.

There are performance implications to resolving those sub-behaviors, so if they don't exist, the built-in behavior won't be registered.