### PR TITLE
Use actual request type in new 'Send' method

### DIFF
--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -63,7 +63,7 @@ public class Mediator : IMediator
             throw new ArgumentNullException(nameof(request));
         }
 
-        var requestType = typeof(TRequest);
+        var requestType = request.GetType();
 
         var handler = (RequestHandlerWrapper)_requestHandlers.GetOrAdd(requestType,
             static t => (RequestHandlerBase)(Activator.CreateInstance(typeof(RequestHandlerWrapperImpl<>).MakeGenericType(t))

--- a/test/MediatR.Tests/PublishTests.cs
+++ b/test/MediatR.Tests/PublishTests.cs
@@ -215,8 +215,9 @@ public class PublishTests
 
         var mediator = container.GetInstance<IMediator>();
 
-        INotification notification = new Ping { Message = "Ping" };
-        await mediator.Publish(notification);
+        // wrap notifications in an array, so this test won't break on a 'replace with var' refactoring
+        var notifications = new INotification[] { new Ping { Message = "Ping" } };
+        await mediator.Publish(notifications[0]);
 
         var result = builder.ToString().Split(new[] { Environment.NewLine }, StringSplitOptions.None);
         result.ShouldContain("Ping Pong");

--- a/test/MediatR.Tests/SendTests.cs
+++ b/test/MediatR.Tests/SendTests.cs
@@ -175,6 +175,31 @@ public class SendTests
         response.Message.ShouldBe("Ping Pong");
     }
 
+    [Fact]
+    public async Task Should_resolve_main_handler_by_given_interface()
+    {
+        var dependency = new Dependency();
+        var container = new Container(cfg =>
+        {
+            cfg.Scan(scanner =>
+            {
+                scanner.AssemblyContainingType(typeof(PublishTests));
+                scanner.IncludeNamespaceContainingType<VoidPing>();
+                scanner.WithDefaultConventions();
+                scanner.AddAllTypesOf(typeof(IRequestHandler<>));
+            });
+            cfg.ForSingletonOf<Dependency>().Use(dependency);
+            cfg.For<ISender>().Use<Mediator>();
+        });
+
+        var mediator = container.GetInstance<ISender>();
+
+        // wrap requests in an array, so this test won't break on a 'replace with var' refactoring
+        var requests = new IRequest[] { new VoidPing() };
+        await mediator.Send(requests[0]);
+
+        dependency.Called.ShouldBeTrue();
+    }
 
     [Fact]
     public async Task Should_raise_execption_on_null_request()


### PR DESCRIPTION
See this old issue for background: https://github.com/jbogard/MediatR/issues/124

```csharp
var requests = new IRequest[] { new Req1(), new Req2(), new Req3() };
foreach (var req in requests)
{
  await _mediator.Send(req);
}
```

It will try to resolve handlers of type "IRequest" instead of using the concrete type of the given request.

sorry I didn't catch that yesterday 😞 let me know if I should add a test