### PR TITLE
Downgrade 7.0.0 Microsoft extensions packages to 6.0.0 and do not reference BCL async interfaces for .NET 6+

### DIFF
--- a/samples/MediatR.Examples.AspNetCore/MediatR.Examples.AspNetCore.csproj
+++ b/samples/MediatR.Examples.AspNetCore/MediatR.Examples.AspNetCore.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/MediatR.Examples.Autofac/MediatR.Examples.Autofac.csproj
+++ b/samples/MediatR.Examples.Autofac/MediatR.Examples.Autofac.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.5.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/MediatR.Examples.DryIoc/MediatR.Examples.DryIoc.csproj
+++ b/samples/MediatR.Examples.DryIoc/MediatR.Examples.DryIoc.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/MediatR.Examples.Lamar/MediatR.Examples.Lamar.csproj
+++ b/samples/MediatR.Examples.Lamar/MediatR.Examples.Lamar.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Lamar" Version="8.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MediatR.Examples.LightInject/MediatR.Examples.LightInject.csproj
+++ b/samples/MediatR.Examples.LightInject/MediatR.Examples.LightInject.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="LightInject" Version="6.6.1" />
     <PackageReference Include="LightInject.Microsoft.DependencyInjection" Version="3.6.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/MediatR.Examples.PublishStrategies/MediatR.Examples.PublishStrategies.csproj
+++ b/samples/MediatR.Examples.PublishStrategies/MediatR.Examples.PublishStrategies.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MediatR.Examples.SimpleInjector/MediatR.Examples.SimpleInjector.csproj
+++ b/samples/MediatR.Examples.SimpleInjector/MediatR.Examples.SimpleInjector.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="SimpleInjector" Version="5.4.1" />
     <PackageReference Include="SimpleInjector.Integration.ServiceCollection" Version="5.4.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/MediatR.Examples.Stashbox/MediatR.Examples.Stashbox.csproj
+++ b/samples/MediatR.Examples.Stashbox/MediatR.Examples.Stashbox.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Stashbox" Version="5.5.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MediatR/MediatR.csproj
+++ b/src/MediatR/MediatR.csproj
@@ -4,7 +4,7 @@
     <Authors>Jimmy Bogard</Authors>
     <Description>Simple, unambitious mediator implementation in .NET</Description>
     <Copyright>Copyright Jimmy Bogard</Copyright>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <Features>strict</Features>
     <PackageTags>mediator;request;response;queries;commands;notifications</PackageTags>
@@ -32,8 +32,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="MediatR.Contracts" Version="[2.0.0, 3.0.0)" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="4.3.0" PrivateAssets="All" />
   </ItemGroup>

--- a/test/MediatR.Tests/MediatR.Tests.csproj
+++ b/test/MediatR.Tests/MediatR.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Shouldly" Version="4.1.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
The [Microsoft.Bcl.AsyncInterfaces](https://www.nuget.org/packages/Microsoft.Bcl.AsyncInterfaces/) package **is not required for .NET framework 6 and later**. By multi-targeting both `netstandard2.0` and `net6.0`, we can add the dependency to `Microsoft.Bcl.AsyncInterfaces` only for `netstandard2.0`, while removing an unnecessary dependency on .NET 6 and later. Microsoft does the same for the [DependencyInjection.Abstractions](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection.Abstractions/6.0.0#dependencies-body-tab) extensions package and many others (see dependencies tab).

Also, targeting a **Microsoft extension library with version 7.x** can be quite annoying for several projects that are using version 6.x of these extensions libraries. Usually, these extensions packages are initially released on the same day than a major version of the framework. So 6.0.0 packages came out for .NET 6, and 7.0.0 packages came out for .NET 7. Also, the end-of-life (EOL) of these packages is bound to the EOL of the corresponding .NET framework. We saw that with .NET 5.

I believe that many consumer applications are still using these 6.x packages, and right now they are kind of "forced" to upgrade to the 7.x version, which doesn't bring any actual value. So my suggestion is the following:

* Target version 6.0.0 for this extension library, so consumers applications are not forced to upgrade to 7.0.0
* Consumer applications that already use version 7.0.0 already won't be impacted at all, we just define the minimum version and the public APIs are completely compatibles