### PR TITLE
Skip unnecessary BCL package reference if targeting .NET 6 or later

### DIFF
--- a/src/MediatR/MediatR.csproj
+++ b/src/MediatR/MediatR.csproj
@@ -4,7 +4,7 @@
     <Authors>Jimmy Bogard</Authors>
     <Description>Simple, unambitious mediator implementation in .NET</Description>
     <Copyright>Copyright Jimmy Bogard</Copyright>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <Features>strict</Features>
     <PackageTags>mediator;request;response;queries;commands;notifications</PackageTags>
@@ -32,7 +32,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="MediatR.Contracts" Version="[2.0.1, 3.0.0)" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="4.3.0" PrivateAssets="All" />

--- a/src/MediatR/Pipeline/RequestExceptionActionProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestExceptionActionProcessorBehavior.cs
@@ -1,6 +1,7 @@
 namespace MediatR.Pipeline;
 
 using Internal;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -71,7 +72,7 @@ public class RequestExceptionActionProcessorBehavior<TRequest, TResponse> : IPip
         var exceptionActionInterfaceType = typeof(IRequestExceptionAction<,>).MakeGenericType(typeof(TRequest), exceptionType);
         var enumerableExceptionActionInterfaceType = typeof(IEnumerable<>).MakeGenericType(exceptionActionInterfaceType);
 
-        var actionsForException = (IEnumerable<object>)_serviceProvider.GetService(enumerableExceptionActionInterfaceType);
+        var actionsForException = (IEnumerable<object>)_serviceProvider.GetRequiredService(enumerableExceptionActionInterfaceType);
 
         return HandlersOrderer.Prioritize(actionsForException.ToList(), request)
             .Select(action => (exceptionType, action));

--- a/src/MediatR/Pipeline/RequestExceptionProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestExceptionProcessorBehavior.cs
@@ -1,6 +1,7 @@
 namespace MediatR.Pipeline;
 
 using Internal;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -88,7 +89,7 @@ public class RequestExceptionProcessorBehavior<TRequest, TResponse> : IPipelineB
         var exceptionHandlerInterfaceType = typeof(IRequestExceptionHandler<,,>).MakeGenericType(typeof(TRequest), typeof(TResponse), exceptionType);
         var enumerableExceptionHandlerInterfaceType = typeof(IEnumerable<>).MakeGenericType(exceptionHandlerInterfaceType);
 
-        var exceptionHandlers = (IEnumerable<object>) _serviceProvider.GetService(enumerableExceptionHandlerInterfaceType);
+        var exceptionHandlers = (IEnumerable<object>) _serviceProvider.GetRequiredService(enumerableExceptionHandlerInterfaceType);
 
         return HandlersOrderer.Prioritize(exceptionHandlers.ToList(), request)
             .Select(handler => (exceptionType, action: handler));

--- a/src/MediatR/Registration/ServiceRegistrar.cs
+++ b/src/MediatR/Registration/ServiceRegistrar.cs
@@ -105,7 +105,7 @@ public static class ServiceRegistrar
         }
     }
 
-    private static bool IsMatchingWithInterface(Type handlerType, Type handlerInterface)
+    private static bool IsMatchingWithInterface(Type? handlerType, Type handlerInterface)
     {
         if (handlerType == null || handlerInterface == null)
         {
@@ -186,15 +186,15 @@ public static class ServiceRegistrar
                 yield return interfaceType;
             }
         }
-        else if (pluggedType.GetTypeInfo().BaseType.GetTypeInfo().IsGenericType &&
-                 (pluggedType.GetTypeInfo().BaseType.GetGenericTypeDefinition() == templateType))
+        else if (pluggedType.GetTypeInfo().BaseType!.GetTypeInfo().IsGenericType &&
+                 (pluggedType.GetTypeInfo().BaseType!.GetGenericTypeDefinition() == templateType))
         {
-            yield return pluggedType.GetTypeInfo().BaseType;
+            yield return pluggedType.GetTypeInfo().BaseType!;
         }
 
         if (pluggedType.GetTypeInfo().BaseType == typeof(object)) yield break;
 
-        foreach (var interfaceType in FindInterfacesThatClosesCore(pluggedType.GetTypeInfo().BaseType, templateType))
+        foreach (var interfaceType in FindInterfacesThatClosesCore(pluggedType.GetTypeInfo().BaseType!, templateType))
         {
             yield return interfaceType;
         }


### PR DESCRIPTION
As mentioned in [#852](https://github.com/jbogard/MediatR/pull/852#issuecomment-1439443067), I would like to introduce multi-targeting **only to skip an unnecessary package reference** (`Microsoft.Bcl.AsyncInterfaces`) on .NET 6 and later, because it's already included by default.

A (positive?) side effect of targeting `net6.0` is that a few warnings appeared in existing code because of new nullable reference types annotations. For instance, `IServiceProvider.GetService(Type serviceType)`:

* Returns `object` in `netstandard2.0`
* Returns `object?` in `net6.0`

At runtime, the behavior is the same. It's just that Microsoft added more hints to prevent null reference exceptions. I had to fix these warnings, and that explains the number of changes.

While fixing these warnings in `Mediator.cs`, I also added:
* Missing `InvalidOperationException` if we can't create the wrapper for stream requests handlers (instead of null-ref ex),
* More consistency in how wrappers are cached in their respective concurrent dictionaries (static delegates everywhere for better memory usage),
* More consistency in `InvalidOperationException` messages