### PR TITLE
Fix runtime exception in DryIoc sample

### DIFF
--- a/samples/MediatR.Examples.DryIoc/Program.cs
+++ b/samples/MediatR.Examples.DryIoc/Program.cs
@@ -20,12 +20,17 @@ class Program
     private static IMediator BuildMediator(WrappingWriter writer)
     {
         var container = new Container();
+        // Since Mediator has multiple constructors, consider adding rule to allow that
+        // var container = new Container(rules => rules.With(FactoryMethod.ConstructorWithResolvableArguments))
 
         container.Use<TextWriter>(writer);
 
         //Pipeline works out of the box here
 
         container.RegisterMany(new[] { typeof(IMediator).GetAssembly(), typeof(Ping).GetAssembly() }, Registrator.Interfaces);
+        //Without the container having FactoryMethod.ConstructorWithResolvableArguments commented above
+        //You must select the desired constructor
+        container.Register<IMediator, Mediator>(made: Made.Of(() => new Mediator(Arg.Of<IServiceProvider>())));
 
         var services = new ServiceCollection();
 


### PR DESCRIPTION
The addition of the second constructor in the Mediator class (for
publishing strategies) breaks the default rules for DryIoc.

This commit will fix that by explicity picking the constructor to use in
the container. It also adds comments for an alternative solution to
automatically resolve classes that have multiple constructors.
