### PR TITLE
This PR  makes the marker interface `INotification` optional.

### DIFF
--- a/samples/MediatR.Examples.PublishStrategies/CustomMediator.cs
+++ b/samples/MediatR.Examples.PublishStrategies/CustomMediator.cs
@@ -7,11 +7,11 @@ namespace MediatR.Examples.PublishStrategies;
 
 public class CustomMediator : Mediator
 {
-    private readonly Func<IEnumerable<NotificationHandlerExecutor>, INotification, CancellationToken, Task> _publish;
+    private readonly Func<IEnumerable<NotificationHandlerExecutor>, object, CancellationToken, Task> _publish;
 
-    public CustomMediator(IServiceProvider serviceFactory, Func<IEnumerable<NotificationHandlerExecutor>, INotification, CancellationToken, Task> publish) : base(serviceFactory) 
+    public CustomMediator(IServiceProvider serviceFactory, Func<IEnumerable<NotificationHandlerExecutor>, object, CancellationToken, Task> publish) : base(serviceFactory)
         => _publish = publish;
 
-    protected override Task PublishCore(IEnumerable<NotificationHandlerExecutor> handlerExecutors, INotification notification, CancellationToken cancellationToken) 
+    protected override Task PublishCore(IEnumerable<NotificationHandlerExecutor> handlerExecutors, object notification, CancellationToken cancellationToken)
         => _publish(handlerExecutors, notification, cancellationToken);
 }

--- a/samples/MediatR.Examples.PublishStrategies/Publisher.cs
+++ b/samples/MediatR.Examples.PublishStrategies/Publisher.cs
@@ -50,7 +50,7 @@ public class Publisher
         return mediator.Publish(notification, cancellationToken);
     }
 
-    private Task ParallelWhenAll(IEnumerable<NotificationHandlerExecutor> handlers, INotification notification, CancellationToken cancellationToken)
+    private Task ParallelWhenAll(IEnumerable<NotificationHandlerExecutor> handlers, object notification, CancellationToken cancellationToken)
     {
         var tasks = new List<Task>();
 
@@ -62,7 +62,7 @@ public class Publisher
         return Task.WhenAll(tasks);
     }
 
-    private Task ParallelWhenAny(IEnumerable<NotificationHandlerExecutor> handlers, INotification notification, CancellationToken cancellationToken)
+    private Task ParallelWhenAny(IEnumerable<NotificationHandlerExecutor> handlers, object notification, CancellationToken cancellationToken)
     {
         var tasks = new List<Task>();
 
@@ -74,7 +74,7 @@ public class Publisher
         return Task.WhenAny(tasks);
     }
 
-    private Task ParallelNoWait(IEnumerable<NotificationHandlerExecutor> handlers, INotification notification, CancellationToken cancellationToken)
+    private Task ParallelNoWait(IEnumerable<NotificationHandlerExecutor> handlers, object notification, CancellationToken cancellationToken)
     {
         foreach (var handler in handlers)
         {
@@ -84,7 +84,7 @@ public class Publisher
         return Task.CompletedTask;
     }
 
-    private async Task AsyncContinueOnException(IEnumerable<NotificationHandlerExecutor> handlers, INotification notification, CancellationToken cancellationToken)
+    private async Task AsyncContinueOnException(IEnumerable<NotificationHandlerExecutor> handlers, object notification, CancellationToken cancellationToken)
     {
         var tasks = new List<Task>();
         var exceptions = new List<Exception>();
@@ -120,7 +120,7 @@ public class Publisher
         }
     }
 
-    private async Task SyncStopOnException(IEnumerable<NotificationHandlerExecutor> handlers, INotification notification, CancellationToken cancellationToken)
+    private async Task SyncStopOnException(IEnumerable<NotificationHandlerExecutor> handlers, object notification, CancellationToken cancellationToken)
     {
         foreach (var handler in handlers)
         {
@@ -128,7 +128,7 @@ public class Publisher
         }
     }
 
-    private async Task SyncContinueOnException(IEnumerable<NotificationHandlerExecutor> handlers, INotification notification, CancellationToken cancellationToken)
+    private async Task SyncContinueOnException(IEnumerable<NotificationHandlerExecutor> handlers, object notification, CancellationToken cancellationToken)
     {
         var exceptions = new List<Exception>();
 

--- a/samples/MediatR.Examples/GenericHandler.cs
+++ b/samples/MediatR.Examples/GenericHandler.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace MediatR.Examples;
 
-public class GenericHandler : INotificationHandler<INotification>
+public class GenericHandler : INotificationHandler<object>
 {
     private readonly TextWriter _writer;
 
@@ -13,7 +13,7 @@ public class GenericHandler : INotificationHandler<INotification>
         _writer = writer;
     }
 
-    public Task Handle(INotification notification, CancellationToken cancellationToken)
+    public Task Handle(object notification, CancellationToken cancellationToken)
     {
         return _writer.WriteLineAsync("Got notified.");
     }

--- a/samples/MediatR.Examples/Pinged.cs
+++ b/samples/MediatR.Examples/Pinged.cs
@@ -1,6 +1,6 @@
 namespace MediatR.Examples;
 
-public class Pinged : INotification
+public class Pinged
 {
-         
+
 }

--- a/samples/MediatR.Examples/Ponged.cs
+++ b/samples/MediatR.Examples/Ponged.cs
@@ -1,6 +1,6 @@
 ﻿namespace MediatR.Examples;
 
-public class Ponged : INotification
+public class Ponged
 {
 
 }

--- a/src/MediatR.Contracts/INotification.cs
+++ b/src/MediatR.Contracts/INotification.cs
@@ -1,6 +1,7 @@
 namespace MediatR;
 
 /// <summary>
-/// Marker interface to represent a notification
+/// Marker interface to represent a notification.
+/// This marker interface is now optional. Any type can be used for notification type, even value tuples.
 /// </summary>
 public interface INotification { }

--- a/src/MediatR/INotificationHandler.cs
+++ b/src/MediatR/INotificationHandler.cs
@@ -8,7 +8,6 @@ namespace MediatR;
 /// </summary>
 /// <typeparam name="TNotification">The type of notification being handled</typeparam>
 public interface INotificationHandler<in TNotification>
-    where TNotification : INotification
 {
     /// <summary>
     /// Handles a notification
@@ -23,7 +22,6 @@ public interface INotificationHandler<in TNotification>
 /// </summary>
 /// <typeparam name="TNotification">The notification type</typeparam>
 public abstract class NotificationHandler<TNotification> : INotificationHandler<TNotification>
-    where TNotification : INotification
 {
     Task INotificationHandler<TNotification>.Handle(TNotification notification, CancellationToken cancellationToken)
     {

--- a/src/MediatR/INotificationPublisher.cs
+++ b/src/MediatR/INotificationPublisher.cs
@@ -1,11 +1,11 @@
 ﻿using System.Collections.Generic;
-using System.Threading.Tasks;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace MediatR;
 
 public interface INotificationPublisher
 {
-    Task Publish(IEnumerable<NotificationHandlerExecutor> handlerExecutors, INotification notification,
+    Task Publish(IEnumerable<NotificationHandlerExecutor> handlerExecutors, object notification,
         CancellationToken cancellationToken);
 }

--- a/src/MediatR/IPublisher.cs
+++ b/src/MediatR/IPublisher.cs
@@ -22,6 +22,5 @@ public interface IPublisher
     /// <param name="notification">Notification object</param>
     /// <param name="cancellationToken">Optional cancellation token</param>
     /// <returns>A task that represents the publish operation.</returns>
-    Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
-        where TNotification : INotification;
+    Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default);
 }

--- a/src/MediatR/NotificationHandlerExecutor.cs
+++ b/src/MediatR/NotificationHandlerExecutor.cs
@@ -4,4 +4,4 @@ using System.Threading.Tasks;
 
 namespace MediatR;
 
-public record NotificationHandlerExecutor(object HandlerInstance, Func<INotification, CancellationToken, Task> HandlerCallback);
+public record NotificationHandlerExecutor(object HandlerInstance, Func<object, CancellationToken, Task> HandlerCallback);

--- a/src/MediatR/NotificationPublishers/ForeachAwaitPublisher.cs
+++ b/src/MediatR/NotificationPublishers/ForeachAwaitPublisher.cs
@@ -14,7 +14,7 @@ namespace MediatR.NotificationPublishers;
 /// </summary>
 public class ForeachAwaitPublisher : INotificationPublisher
 {
-    public async Task Publish(IEnumerable<NotificationHandlerExecutor> handlerExecutors, INotification notification, CancellationToken cancellationToken)
+    public async Task Publish(IEnumerable<NotificationHandlerExecutor> handlerExecutors, object notification, CancellationToken cancellationToken)
     {
         foreach (var handler in handlerExecutors)
         {

--- a/src/MediatR/NotificationPublishers/TaskWhenAllPublisher.cs
+++ b/src/MediatR/NotificationPublishers/TaskWhenAllPublisher.cs
@@ -17,7 +17,7 @@ namespace MediatR.NotificationPublishers;
 /// </summary>
 public class TaskWhenAllPublisher : INotificationPublisher
 {
-    public Task Publish(IEnumerable<NotificationHandlerExecutor> handlerExecutors, INotification notification, CancellationToken cancellationToken)
+    public Task Publish(IEnumerable<NotificationHandlerExecutor> handlerExecutors, object notification, CancellationToken cancellationToken)
     {
         var tasks = handlerExecutors
             .Select(handler => handler.HandlerCallback(notification, cancellationToken))

--- a/src/MediatR/TypeForwardings.cs
+++ b/src/MediatR/TypeForwardings.cs
@@ -1,8 +1,7 @@
-﻿using System.Runtime.CompilerServices;
-using MediatR;
+﻿using MediatR;
+using System.Runtime.CompilerServices;
 
 [assembly: TypeForwardedTo(typeof(IBaseRequest))]
 [assembly: TypeForwardedTo(typeof(IRequest<>))]
 [assembly: TypeForwardedTo(typeof(IRequest))]
-[assembly: TypeForwardedTo(typeof(INotification))]
 [assembly: TypeForwardedTo(typeof(Unit))]

--- a/src/MediatR/Wrappers/NotificationHandlerWrapper.cs
+++ b/src/MediatR/Wrappers/NotificationHandlerWrapper.cs
@@ -1,29 +1,28 @@
 namespace MediatR.Wrappers;
 
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 
 public abstract class NotificationHandlerWrapper
 {
-    public abstract Task Handle(INotification notification, IServiceProvider serviceFactory,
-        Func<IEnumerable<NotificationHandlerExecutor>, INotification, CancellationToken, Task> publish,
+    public abstract Task Handle(object notification, IServiceProvider serviceFactory,
+        Func<IEnumerable<NotificationHandlerExecutor>, object, CancellationToken, Task> publish,
         CancellationToken cancellationToken);
 }
 
 public class NotificationHandlerWrapperImpl<TNotification> : NotificationHandlerWrapper
-    where TNotification : INotification
 {
-    public override Task Handle(INotification notification, IServiceProvider serviceFactory,
-        Func<IEnumerable<NotificationHandlerExecutor>, INotification, CancellationToken, Task> publish,
+    public override Task Handle(object notification, IServiceProvider serviceFactory,
+        Func<IEnumerable<NotificationHandlerExecutor>, object, CancellationToken, Task> publish,
         CancellationToken cancellationToken)
     {
         var handlers = serviceFactory
             .GetServices<INotificationHandler<TNotification>>()
-            .Select(static x => new NotificationHandlerExecutor(x, (theNotification, theToken) => x.Handle((TNotification)theNotification, theToken)));
+            .Select(static x => new NotificationHandlerExecutor(x, (theNotification, theToken) => x.Handle((TNotification) theNotification, theToken)));
 
         return publish(handlers, notification, cancellationToken);
     }

--- a/test/MediatR.Benchmarks/Pinged.cs
+++ b/test/MediatR.Benchmarks/Pinged.cs
@@ -1,6 +1,6 @@
 namespace MediatR.Benchmarks
 {
-    public class Pinged : INotification
+    public class Pinged
     {
 
     }

--- a/test/MediatR.Tests/ExceptionTests.cs
+++ b/test/MediatR.Tests/ExceptionTests.cs
@@ -2,12 +2,12 @@ using System.Threading;
 
 namespace MediatR.Tests;
 
+using Lamar;
+using Lamar.IoC;
+using Shouldly;
 using System;
 using System.Threading.Tasks;
-using Shouldly;
-using Lamar;
 using Xunit;
-using Lamar.IoC;
 
 public class ExceptionTests
 {
@@ -25,7 +25,7 @@ public class ExceptionTests
     {
     }
 
-    public class Pinged : INotification
+    public class Pinged
     {
     }
 
@@ -37,7 +37,7 @@ public class ExceptionTests
     {
     }
 
-    public class AsyncPinged : INotification
+    public class AsyncPinged
     {
     }
 
@@ -49,7 +49,7 @@ public class ExceptionTests
     {
     }
 
-    public class NullPinged : INotification
+    public class NullPinged
     {
     }
 
@@ -217,7 +217,7 @@ public class ExceptionTests
     }
 
     [Fact]
-    public async Task Should_throw_argument_exception_for_publish_when_request_is_not_notification()
+    public async Task Should_not_throw_argument_exception_for_publish_when_request_is_not_notification()
     {
         var container = new Container(cfg =>
         {
@@ -234,7 +234,7 @@ public class ExceptionTests
 
         object notification = "totally not notification";
 
-        await Should.ThrowAsync<ArgumentException>(async () => await mediator.Publish(notification));
+        await Should.NotThrowAsync(async () => await mediator.Publish(notification));
     }
 
     public class PingException : IRequest

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/Handlers.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/Handlers.cs
@@ -37,7 +37,7 @@ namespace MediatR.Extensions.Microsoft.DependencyInjection.Tests
         public string? Message { get; init; }
     }
 
-    public class Pinged : INotification
+    public class Pinged
     {
 
     }
@@ -49,9 +49,9 @@ namespace MediatR.Extensions.Microsoft.DependencyInjection.Tests
         public string? Message { get; init; }
     }
 
-    public class GenericHandler : INotificationHandler<INotification>
+    public class GenericHandler : INotificationHandler<object>
     {
-        public Task Handle(INotification notification, CancellationToken cancellationToken)
+        public Task Handle(object notification, CancellationToken cancellationToken)
         {
             return Task.FromResult(0);
         }
@@ -192,7 +192,7 @@ namespace MediatR.Extensions.Microsoft.DependencyInjection.Tests
             throw new System.NotImplementedException();
         }
 
-        public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default) where TNotification : INotification
+        public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
         {
             throw new System.NotImplementedException();
         }

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/NotificationPublisherTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/NotificationPublisherTests.cs
@@ -1,11 +1,9 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using System;
+﻿using MediatR.NotificationPublishers;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using MediatR.NotificationPublishers;
-using Shouldly;
 using Xunit;
 
 namespace MediatR.Extensions.Microsoft.DependencyInjection.Tests;
@@ -16,7 +14,7 @@ public class NotificationPublisherTests
     {
         public int CallCount { get; set; }
 
-        public async Task Publish(IEnumerable<NotificationHandlerExecutor> handlerExecutors, INotification notification, CancellationToken cancellationToken)
+        public async Task Publish(IEnumerable<NotificationHandlerExecutor> handlerExecutors, object notification, CancellationToken cancellationToken)
         {
             foreach (var handlerExecutor in handlerExecutors)
             {
@@ -64,7 +62,7 @@ public class NotificationPublisherTests
         mediator.ShouldNotBeNull();
 
         await mediator.Publish(new Pinged());
-        
+
         publisher.CallCount.ShouldBeGreaterThan(0);
     }
 

--- a/test/MediatR.Tests/NotificationHandlerTests.cs
+++ b/test/MediatR.Tests/NotificationHandlerTests.cs
@@ -1,14 +1,14 @@
+using Shouldly;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
-using Shouldly;
 using Xunit;
 
 namespace MediatR.Tests;
 
 public class NotificationHandlerTests
 {
-    public class Ping : INotification
+    public class Ping
     {
         public string? Message { get; set; }
     }

--- a/test/MediatR.Tests/NotificationPublisherTests.cs
+++ b/test/MediatR.Tests/NotificationPublisherTests.cs
@@ -1,9 +1,9 @@
-﻿using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
-using MediatR.NotificationPublishers;
+﻿using MediatR.NotificationPublishers;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,18 +15,18 @@ public class NotificationPublisherTests
 
     public NotificationPublisherTests(ITestOutputHelper output) => _output = output;
 
-    public class Notification : INotification
+    public class Notification
     {
     }
 
     public class FirstHandler : INotificationHandler<Notification>
     {
-        public async Task Handle(Notification notification, CancellationToken cancellationToken) 
+        public async Task Handle(Notification notification, CancellationToken cancellationToken)
             => await Task.Delay(500, cancellationToken);
     }
     public class SecondHandler : INotificationHandler<Notification>
     {
-        public async Task Handle(Notification notification, CancellationToken cancellationToken) 
+        public async Task Handle(Notification notification, CancellationToken cancellationToken)
             => await Task.Delay(250, cancellationToken);
     }
 
@@ -48,7 +48,7 @@ public class NotificationPublisherTests
         await mediator.Publish(new Notification());
 
         timer.Stop();
-        
+
         var sequentialElapsed = timer.ElapsedMilliseconds;
 
         services = new ServiceCollection();
@@ -66,7 +66,7 @@ public class NotificationPublisherTests
         await mediator.Publish(new Notification());
 
         timer.Stop();
-        
+
         var parallelElapsed = timer.ElapsedMilliseconds;
 
         sequentialElapsed.ShouldBeGreaterThan(parallelElapsed);

--- a/test/MediatR.Tests/PublishTests.cs
+++ b/test/MediatR.Tests/PublishTests.cs
@@ -2,18 +2,18 @@ using System.Threading;
 
 namespace MediatR.Tests;
 
+using Lamar;
+using Shouldly;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
-using Shouldly;
-using Lamar;
 using Xunit;
 
 public class PublishTests
 {
-    public class Ping : INotification
+    public class Ping
     {
         public string? Message { get; set; }
     }
@@ -61,7 +61,7 @@ public class PublishTests
                 scanner.AssemblyContainingType(typeof(PublishTests));
                 scanner.IncludeNamespaceContainingType<Ping>();
                 scanner.WithDefaultConventions();
-                scanner.AddAllTypesOf(typeof (INotificationHandler<>));
+                scanner.AddAllTypesOf(typeof(INotificationHandler<>));
             });
             cfg.For<TextWriter>().Use(writer);
             cfg.For<IMediator>().Use<Mediator>();
@@ -71,7 +71,7 @@ public class PublishTests
 
         await mediator.Publish(new Ping { Message = "Ping" });
 
-        var result = builder.ToString().Split(new [] {Environment.NewLine}, StringSplitOptions.None);
+        var result = builder.ToString().Split(new[] { Environment.NewLine }, StringSplitOptions.None);
         result.ShouldContain("Ping Pong");
         result.ShouldContain("Ping Pung");
     }
@@ -89,7 +89,7 @@ public class PublishTests
                 scanner.AssemblyContainingType(typeof(PublishTests));
                 scanner.IncludeNamespaceContainingType<Ping>();
                 scanner.WithDefaultConventions();
-                scanner.AddAllTypesOf(typeof (INotificationHandler<>));
+                scanner.AddAllTypesOf(typeof(INotificationHandler<>));
             });
             cfg.For<TextWriter>().Use(writer);
             cfg.For<IMediator>().Use<Mediator>();
@@ -100,7 +100,7 @@ public class PublishTests
         object message = new Ping { Message = "Ping" };
         await mediator.Publish(message);
 
-        var result = builder.ToString().Split(new [] {Environment.NewLine}, StringSplitOptions.None);
+        var result = builder.ToString().Split(new[] { Environment.NewLine }, StringSplitOptions.None);
         result.ShouldContain("Ping Pong");
         result.ShouldContain("Ping Pung");
     }
@@ -112,7 +112,7 @@ public class PublishTests
         {
         }
 
-        protected override async Task PublishCore(IEnumerable<NotificationHandlerExecutor> allHandlers, INotification notification, CancellationToken cancellationToken)
+        protected override async Task PublishCore(IEnumerable<NotificationHandlerExecutor> allHandlers, object notification, CancellationToken cancellationToken)
         {
             foreach (var handler in allHandlers)
             {
@@ -125,7 +125,7 @@ public class PublishTests
     {
         public int CallCount { get; set; }
 
-        public async Task Publish(IEnumerable<NotificationHandlerExecutor> handlerExecutors, INotification notification, CancellationToken cancellationToken)
+        public async Task Publish(IEnumerable<NotificationHandlerExecutor> handlerExecutors, object notification, CancellationToken cancellationToken)
         {
             foreach (var handler in handlerExecutors)
             {
@@ -216,7 +216,7 @@ public class PublishTests
         var mediator = container.GetInstance<IMediator>();
 
         // wrap notifications in an array, so this test won't break on a 'replace with var' refactoring
-        var notifications = new INotification[] { new Ping { Message = "Ping" } };
+        var notifications = new object[] { new Ping { Message = "Ping" } };
         await mediator.Publish(notifications[0]);
 
         var result = builder.ToString().Split(new[] { Environment.NewLine }, StringSplitOptions.None);
@@ -237,7 +237,7 @@ public class PublishTests
                 scanner.AssemblyContainingType(typeof(PublishTests));
                 scanner.IncludeNamespaceContainingType<Ping>();
                 scanner.WithDefaultConventions();
-                scanner.AddAllTypesOf(typeof (INotificationHandler<>));
+                scanner.AddAllTypesOf(typeof(INotificationHandler<>));
             });
             cfg.For<TextWriter>().Use(writer);
             cfg.For<IPublisher>().Use<Mediator>();
@@ -247,7 +247,7 @@ public class PublishTests
 
         await mediator.Publish(new Ping { Message = "Ping" });
 
-        var result = builder.ToString().Split(new [] {Environment.NewLine}, StringSplitOptions.None);
+        var result = builder.ToString().Split(new[] { Environment.NewLine }, StringSplitOptions.None);
         result.ShouldContain("Ping Pong");
         result.ShouldContain("Ping Pung");
     }


### PR DESCRIPTION
`INotification` is an unnecessary constraint. It's absence does not prevent the correct functioning of `INotificationHandler`/`INotificationPublisher`.

This avoids the creation of a specific type for each notification type, and allows us to define handlers using value tuples:

~~~csharp
public class Entity
{
}

public enum Operation
{
  Create,
  Update
}

public class EntityEventHandler : INotificationHandler<(Entity Entity, Operation Operation)>
{

    public Task Handle((Entity Entity, Operation Operation) notification, CancellationToken cancellationToken)
    {
    }
}

~~~

... and then call them using a syntax like:

~~~csharp
        mediator.Publish((entity, Operation.Create));
~~~