### PR TITLE
Explicit processor registration

### DIFF
--- a/test/MediatR.Tests/MicrosoftExtensionsDI/PipeLineMultiCallToConstructorTest.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/PipeLineMultiCallToConstructorTest.cs
@@ -81,7 +81,11 @@ public class PipelineMultiCallToConstructorTests
 
         services.AddSingleton(output);
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ConstructorTestBehavior<,>));
-        services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(Ping).Assembly));
+        services.AddMediatR(cfg =>
+        {
+            cfg.RegisterServicesFromAssembly(typeof(Ping).Assembly);
+            cfg.AddOpenBehavior(typeof(ConstructorTestBehavior<,>));
+        });
         var provider = services.BuildServiceProvider();
 
         var mediator = provider.GetRequiredService<IMediator>();
@@ -93,11 +97,7 @@ public class PipelineMultiCallToConstructorTests
         output.Messages.ShouldBe(new[]
         {
             "ConstructorTestBehavior before",
-            "First pre processor",
-            "Next pre processor",
             "Handler",
-            "First post processor",
-            "Next post processor",
             "ConstructorTestBehavior after"
         });
         ConstructorTestHandler.ConstructorCallCount.ShouldBe(1);


### PR DESCRIPTION
Removes automatic scanning of pre/post processors and has them explicitly registered. Also adds methods to infer the service types based on only passing in the implementation types.

Fixes #885, fixes #868