### PR TITLE
Applied the newer code analysis rules.

### DIFF
--- a/src/MediatR/Internal/ObjectDetails.cs
+++ b/src/MediatR/Internal/ObjectDetails.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace MediatR.Internal;
 
-internal class ObjectDetails : IComparer<ObjectDetails>
+internal sealed class ObjectDetails : IComparer<ObjectDetails>
 {
     public string Name { get; }
 

--- a/src/MediatR/Internal/ObjectExtensions.cs
+++ b/src/MediatR/Internal/ObjectExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace MediatR.Internal
+{
+    internal static class ObjectExtensions
+    {
+        public static void ThrowIfNull(this object obj, [CallerArgumentExpression("obj")] string name = "")
+        {
+            if (obj is null)
+                throw new ArgumentNullException(name);
+        }
+    }
+}
+
+#if !NET6_0_OR_GREATER
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    internal sealed class CallerArgumentExpressionAttribute : Attribute
+    {
+        public CallerArgumentExpressionAttribute(string parameterName)
+        {
+            ParameterName = parameterName;
+        }
+
+        public string ParameterName { get; }
+    }
+}
+#endif

--- a/src/MediatR/MediatR.csproj
+++ b/src/MediatR/MediatR.csproj
@@ -22,7 +22,7 @@
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
     <AnalysisLevel>latest-All</AnalysisLevel>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);CA1031;CA1040;CA1307;CA1711;CA1716;CA1812</NoWarn>
+    <NoWarn>$(NoWarn);CA1014;CA1031;CA1040;CA1307;CA1711;CA1716;CA1812</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MediatR/MediatR.csproj
+++ b/src/MediatR/MediatR.csproj
@@ -20,6 +20,9 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+    <AnalysisLevel>latest-All</AnalysisLevel>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);CA1031;CA1040;CA1307;CA1711;CA1716;CA1812</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -1,3 +1,4 @@
+using MediatR.Internal;
 using MediatR.NotificationPublishers;
 
 namespace MediatR;
@@ -41,10 +42,7 @@ public class Mediator : IMediator
 
     public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)
     {
-        if (request == null)
-        {
-            throw new ArgumentNullException(nameof(request));
-        }
+        request.ThrowIfNull();
 
         var handler = (RequestHandlerWrapper<TResponse>)_requestHandlers.GetOrAdd(request.GetType(), static requestType =>
         {
@@ -76,10 +74,7 @@ public class Mediator : IMediator
 
     public Task<object?> Send(object request, CancellationToken cancellationToken = default)
     {
-        if (request == null)
-        {
-            throw new ArgumentNullException(nameof(request));
-        }
+        request.ThrowIfNull();
 
         var handler = _requestHandlers.GetOrAdd(request.GetType(), static requestType =>
         {
@@ -154,10 +149,7 @@ public class Mediator : IMediator
 
     public IAsyncEnumerable<TResponse> CreateStream<TResponse>(IStreamRequest<TResponse> request, CancellationToken cancellationToken = default)
     {
-        if (request == null)
-        {
-            throw new ArgumentNullException(nameof(request));
-        }
+        request.ThrowIfNull();
 
         var streamHandler = (StreamRequestHandlerWrapper<TResponse>)_streamRequestHandlers.GetOrAdd(request.GetType(), static requestType =>
         {
@@ -174,10 +166,7 @@ public class Mediator : IMediator
 
     public IAsyncEnumerable<object?> CreateStream(object request, CancellationToken cancellationToken = default)
     {
-        if (request == null)
-        {
-            throw new ArgumentNullException(nameof(request));
-        }
+        request.ThrowIfNull();
 
         var handler = _streamRequestHandlers.GetOrAdd(request.GetType(), static requestType =>
         {

--- a/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
+++ b/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using MediatR;
+using MediatR.Internal;
 using MediatR.NotificationPublishers;
 using MediatR.Pipeline;
 using MediatR.Registration;
@@ -78,7 +79,11 @@ public class MediatRServiceConfiguration
     /// <param name="type">Type from assembly to scan</param>
     /// <returns>This</returns>
     public MediatRServiceConfiguration RegisterServicesFromAssemblyContaining(Type type)
-        => RegisterServicesFromAssembly(type.Assembly);
+    {
+        type.ThrowIfNull();
+
+        return RegisterServicesFromAssembly(type.Assembly);
+    }
 
     /// <summary>
     /// Register various handlers from assembly
@@ -134,6 +139,8 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddBehavior(Type implementationType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
     {
+        implementationType.ThrowIfNull();
+        
         var implementedGenericInterfaces = implementationType.FindInterfacesThatClose(typeof(IPipelineBehavior<,>)).ToList();
 
         if (implementedGenericInterfaces.Count == 0)
@@ -171,6 +178,8 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddOpenBehavior(Type openBehaviorType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
     {
+        openBehaviorType.ThrowIfNull();
+
         if (!openBehaviorType.IsGenericType)
         {
             throw new InvalidOperationException($"{openBehaviorType.Name} must be generic");
@@ -233,6 +242,8 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddStreamBehavior(Type implementationType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
     {
+        implementationType.ThrowIfNull();
+
         var implementedGenericInterfaces = implementationType.FindInterfacesThatClose(typeof(IStreamPipelineBehavior<,>)).ToList();
 
         if (implementedGenericInterfaces.Count == 0)
@@ -256,6 +267,8 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddOpenStreamBehavior(Type openBehaviorType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
     {
+        openBehaviorType.ThrowIfNull();
+
         if (!openBehaviorType.IsGenericType)
         {
             throw new InvalidOperationException($"{openBehaviorType.Name} must be generic");
@@ -319,6 +332,8 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddRequestPreProcessor(Type implementationType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
     {
+        implementationType.ThrowIfNull();
+
         var implementedGenericInterfaces = implementationType.FindInterfacesThatClose(typeof(IRequestPreProcessor<>)).ToList();
 
         if (implementedGenericInterfaces.Count == 0)
@@ -342,6 +357,8 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddOpenRequestPreProcessor(Type openBehaviorType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
     {
+        openBehaviorType.ThrowIfNull();
+
         if (!openBehaviorType.IsGenericType)
         {
             throw new InvalidOperationException($"{openBehaviorType.Name} must be generic");
@@ -404,6 +421,8 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddRequestPostProcessor(Type implementationType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
     {
+        implementationType.ThrowIfNull();
+
         var implementedGenericInterfaces = implementationType.FindInterfacesThatClose(typeof(IRequestPostProcessor<,>)).ToList();
 
         if (implementedGenericInterfaces.Count == 0)
@@ -426,6 +445,8 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddOpenRequestPostProcessor(Type openBehaviorType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
     {
+        openBehaviorType.ThrowIfNull();
+
         if (!openBehaviorType.IsGenericType)
         {
             throw new InvalidOperationException($"{openBehaviorType.Name} must be generic");

--- a/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
+++ b/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
@@ -47,22 +47,22 @@ public class MediatRServiceConfiguration
     /// <summary>
     /// List of behaviors to register in specific order
     /// </summary>
-    public List<ServiceDescriptor> BehaviorsToRegister { get; } = new();
+    public IList<ServiceDescriptor> BehaviorsToRegister { get; } = new List<ServiceDescriptor>();
 
     /// <summary>
     /// List of stream behaviors to register in specific order
     /// </summary>
-    public List<ServiceDescriptor> StreamBehaviorsToRegister { get; } = new();
+    public IList<ServiceDescriptor> StreamBehaviorsToRegister { get; } = new List<ServiceDescriptor>();
 
     /// <summary>
     /// List of request pre processors to register in specific order
     /// </summary>
-    public List<ServiceDescriptor> RequestPreProcessorsToRegister { get; } = new();
+    public IList<ServiceDescriptor> RequestPreProcessorsToRegister { get; } = new List<ServiceDescriptor>();
 
     /// <summary>
     /// List of request post processors to register in specific order
     /// </summary>
-    public List<ServiceDescriptor> RequestPostProcessorsToRegister { get; } = new();
+    public IList<ServiceDescriptor> RequestPostProcessorsToRegister { get; } = new List<ServiceDescriptor>();
 
     /// <summary>
     /// Register various handlers from assembly containing given type

--- a/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
+++ b/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
@@ -15,7 +15,7 @@ public class MediatRServiceConfiguration
     /// <summary>
     /// Optional filter for types to register. Default value is a function returning true.
     /// </summary>
-    public Func<Type, bool> TypeEvaluator { get; set; } = t => true;
+    public Func<Type, bool> TypeEvaluator { get; set; } = _ => true;
     
     /// <summary>
     /// Mediator implementation type to register. Default is <see cref="Mediator"/>

--- a/src/MediatR/MicrosoftExtensionsDI/ServiceCollectionExtensions.cs
+++ b/src/MediatR/MicrosoftExtensionsDI/ServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using MediatR;
 using MediatR.Internal;
 using MediatR.Pipeline;

--- a/src/MediatR/MicrosoftExtensionsDI/ServiceCollectionExtensions.cs
+++ b/src/MediatR/MicrosoftExtensionsDI/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using MediatR;
+using MediatR.Internal;
 using MediatR.Pipeline;
 using MediatR.Registration;
 
@@ -26,6 +27,8 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddMediatR(this IServiceCollection services, 
         Action<MediatRServiceConfiguration> configuration)
     {
+        configuration.ThrowIfNull();
+
         var serviceConfig = new MediatRServiceConfiguration();
 
         configuration.Invoke(serviceConfig);
@@ -42,6 +45,8 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddMediatR(this IServiceCollection services, 
         MediatRServiceConfiguration configuration)
     {
+        configuration.ThrowIfNull();
+
         if (configuration.AssembliesToRegister.Count == 0)
         {
             throw new ArgumentException("No assemblies found to scan. Supply at least one assembly to scan for handlers.");

--- a/src/MediatR/MicrosoftExtensionsDI/ServiceCollectionExtensions.cs
+++ b/src/MediatR/MicrosoftExtensionsDI/ServiceCollectionExtensions.cs
@@ -42,7 +42,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddMediatR(this IServiceCollection services, 
         MediatRServiceConfiguration configuration)
     {
-        if (!configuration.AssembliesToRegister.Any())
+        if (configuration.AssembliesToRegister.Count == 0)
         {
             throw new ArgumentException("No assemblies found to scan. Supply at least one assembly to scan for handlers.");
         }

--- a/src/MediatR/NotificationPublishers/ForeachAwaitPublisher.cs
+++ b/src/MediatR/NotificationPublishers/ForeachAwaitPublisher.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using MediatR.Internal;
 
 namespace MediatR.NotificationPublishers;
 
@@ -16,6 +17,8 @@ public class ForeachAwaitPublisher : INotificationPublisher
 {
     public async Task Publish(IEnumerable<NotificationHandlerExecutor> handlerExecutors, INotification notification, CancellationToken cancellationToken)
     {
+        handlerExecutors.ThrowIfNull();
+
         foreach (var handler in handlerExecutors)
         {
             await handler.HandlerCallback(notification, cancellationToken).ConfigureAwait(false);

--- a/src/MediatR/Pipeline/RequestExceptionActionProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestExceptionActionProcessorBehavior.cs
@@ -25,6 +25,8 @@ public class RequestExceptionActionProcessorBehavior<TRequest, TResponse> : IPip
 
     public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
+        next.ThrowIfNull();
+
         try
         {
             return await next().ConfigureAwait(false);

--- a/src/MediatR/Pipeline/RequestExceptionProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestExceptionProcessorBehavior.cs
@@ -25,6 +25,8 @@ public class RequestExceptionProcessorBehavior<TRequest, TResponse> : IPipelineB
 
     public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
+        next.ThrowIfNull();
+
         try
         {
             return await next().ConfigureAwait(false);

--- a/src/MediatR/Pipeline/RequestPostProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestPostProcessorBehavior.cs
@@ -1,3 +1,5 @@
+using MediatR.Internal;
+
 namespace MediatR.Pipeline;
 
 using System.Collections.Generic;
@@ -19,6 +21,8 @@ public class RequestPostProcessorBehavior<TRequest, TResponse> : IPipelineBehavi
 
     public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
+        next.ThrowIfNull();
+        
         var response = await next().ConfigureAwait(false);
 
         foreach (var processor in _postProcessors)

--- a/src/MediatR/Pipeline/RequestPreProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestPreProcessorBehavior.cs
@@ -1,3 +1,5 @@
+using MediatR.Internal;
+
 namespace MediatR.Pipeline;
 
 using System.Collections.Generic;
@@ -19,6 +21,8 @@ public class RequestPreProcessorBehavior<TRequest, TResponse> : IPipelineBehavio
 
     public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
+        next.ThrowIfNull();
+
         foreach (var processor in _preProcessors)
         {
             await processor.Process(request, cancellationToken).ConfigureAwait(false);

--- a/src/MediatR/Registration/ServiceRegistrar.cs
+++ b/src/MediatR/Registration/ServiceRegistrar.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using MediatR.Internal;
 using MediatR.Pipeline;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -12,6 +13,8 @@ public static class ServiceRegistrar
 {
     public static void AddMediatRClasses(IServiceCollection services, MediatRServiceConfiguration configuration)
     {
+        configuration.ThrowIfNull();
+
         var assembliesToScan = configuration.AssembliesToRegister.Distinct().ToArray();
 
         ConnectImplementationsToTypesClosing(typeof(IRequestHandler<,>), services, assembliesToScan, false, configuration);
@@ -209,6 +212,8 @@ public static class ServiceRegistrar
 
     public static void AddRequiredServices(IServiceCollection services, MediatRServiceConfiguration serviceConfiguration)
     {
+        serviceConfiguration.ThrowIfNull();
+
         // Use TryAdd, so any existing ServiceFactory/IMediator registration doesn't get overridden
         services.TryAdd(new ServiceDescriptor(typeof(IMediator), serviceConfiguration.MediatorImplementationType, serviceConfiguration.Lifetime));
         services.TryAdd(new ServiceDescriptor(typeof(ISender), sp => sp.GetRequiredService<IMediator>(), serviceConfiguration.Lifetime));

--- a/src/MediatR/Registration/ServiceRegistrar.cs
+++ b/src/MediatR/Registration/ServiceRegistrar.cs
@@ -58,7 +58,7 @@ public static class ServiceRegistrar
         foreach (var type in assembliesToScan.SelectMany(a => a.DefinedTypes).Where(t => !t.IsOpenGeneric()).Where(configuration.TypeEvaluator))
         {
             var interfaceTypes = type.FindInterfacesThatClose(openRequestInterface).ToArray();
-            if (!interfaceTypes.Any()) continue;
+            if (interfaceTypes.Length == 0) continue;
 
             if (type.IsConcrete())
             {
@@ -232,13 +232,13 @@ public static class ServiceRegistrar
             RegisterBehaviorIfImplementationsExist(services, typeof(RequestExceptionActionProcessorBehavior<,>), typeof(IRequestExceptionAction<,>));
         }
 
-        if (serviceConfiguration.RequestPreProcessorsToRegister.Any())
+        if (serviceConfiguration.RequestPreProcessorsToRegister.Count != 0)
         {
             services.TryAddEnumerable(new ServiceDescriptor(typeof(IPipelineBehavior<,>), typeof(RequestPreProcessorBehavior<,>), ServiceLifetime.Transient));
             services.TryAddEnumerable(serviceConfiguration.RequestPreProcessorsToRegister);
         }
 
-        if (serviceConfiguration.RequestPostProcessorsToRegister.Any())
+        if (serviceConfiguration.RequestPostProcessorsToRegister.Count != 0)
         {
             services.TryAddEnumerable(new ServiceDescriptor(typeof(IPipelineBehavior<,>), typeof(RequestPostProcessorBehavior<,>), ServiceLifetime.Transient));
             services.TryAddEnumerable(serviceConfiguration.RequestPostProcessorsToRegister);

--- a/src/MediatR/Registration/ServiceRegistrar.cs
+++ b/src/MediatR/Registration/ServiceRegistrar.cs
@@ -201,7 +201,7 @@ public static class ServiceRegistrar
         return !type.IsAbstract && !type.IsInterface;
     }
 
-    private static void Fill<T>(this IList<T> list, T value)
+    private static void Fill<T>(this List<T> list, T value)
     {
         if (list.Contains(value)) return;
         list.Add(value);

--- a/src/MediatR/Registration/ServiceRegistrar.cs
+++ b/src/MediatR/Registration/ServiceRegistrar.cs
@@ -141,7 +141,7 @@ public static class ServiceRegistrar
         }
     }
 
-    internal static bool CouldCloseTo(this Type openConcretion, Type closedInterface)
+    private static bool CouldCloseTo(this Type openConcretion, Type closedInterface)
     {
         var openInterface = closedInterface.GetGenericTypeDefinition();
         var arguments = closedInterface.GenericTypeArguments;

--- a/src/MediatR/Wrappers/NotificationHandlerWrapper.cs
+++ b/src/MediatR/Wrappers/NotificationHandlerWrapper.cs
@@ -1,3 +1,5 @@
+using MediatR.Internal;
+
 namespace MediatR.Wrappers;
 
 using System;
@@ -21,6 +23,8 @@ public class NotificationHandlerWrapperImpl<TNotification> : NotificationHandler
         Func<IEnumerable<NotificationHandlerExecutor>, INotification, CancellationToken, Task> publish,
         CancellationToken cancellationToken)
     {
+        publish.ThrowIfNull();
+
         var handlers = serviceFactory
             .GetServices<INotificationHandler<TNotification>>()
             .Select(static x => new NotificationHandlerExecutor(x, (theNotification, theToken) => x.Handle((TNotification)theNotification, theToken)));

--- a/src/MediatR/Wrappers/RequestHandlerWrapper.cs
+++ b/src/MediatR/Wrappers/RequestHandlerWrapper.cs
@@ -58,7 +58,8 @@ public class RequestHandlerWrapperImpl<TRequest> : RequestHandlerWrapper
         async Task<Unit> Handler()
         {
             await serviceProvider.GetRequiredService<IRequestHandler<TRequest>>()
-                .Handle((TRequest) request, cancellationToken);
+                .Handle((TRequest) request, cancellationToken)
+                .ConfigureAwait(false);
 
             return Unit.Value;
         }

--- a/src/MediatR/Wrappers/StreamRequestHandlerWrapper.cs
+++ b/src/MediatR/Wrappers/StreamRequestHandlerWrapper.cs
@@ -22,7 +22,7 @@ internal abstract class StreamRequestHandlerWrapper<TResponse> : StreamRequestHa
         CancellationToken cancellationToken);
 }
 
-internal class StreamRequestHandlerWrapperImpl<TRequest, TResponse> 
+internal sealed class StreamRequestHandlerWrapperImpl<TRequest, TResponse> 
     : StreamRequestHandlerWrapper<TResponse>
     where TRequest : IStreamRequest<TResponse>
 {


### PR DESCRIPTION
Starting with .NET 5, there are new [code analysis rules](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#code-analysis-properties) being shipped with each release of the .NET SDK.

Since they're mostly straightforward fixes, I addressed the following rules:
- [CA1002: Do not expose generic lists](https://learn.microsoft.com/en-ca/dotnet/fundamentals/code-analysis/quality-rules/ca1002) 
- [CA1062: Validate arguments of public methods](https://learn.microsoft.com/en-ca/dotnet/fundamentals/code-analysis/quality-rules/ca1062) 
- [CA1859: Use concrete types when possible for improved performance](https://learn.microsoft.com/en-ca/dotnet/fundamentals/code-analysis/quality-rules/ca1859) 
- [CA1852: Seal internal types](https://learn.microsoft.com/en-ca/dotnet/fundamentals/code-analysis/quality-rules/ca1852) 
- [CA1860: Avoid using 'Enumerable.Any()' extension method](https://learn.microsoft.com/en-ca/dotnet/fundamentals/code-analysis/quality-rules/ca1860) 
- [CA2007: Do not directly await a Task](https://learn.microsoft.com/en-ca/dotnet/fundamentals/code-analysis/quality-rules/ca2007)

Due to the nature of the project, some rules wouldn't make sense, therefore I muted the following rules:
- [CA1031: Do not catch general exception types](https://learn.microsoft.com/en-ca/dotnet/fundamentals/code-analysis/quality-rules/ca1031)
- [CA1040: Avoid empty interfaces](https://learn.microsoft.com/en-ca/dotnet/fundamentals/code-analysis/quality-rules/ca1040)
- [CA1307: Specify StringComparison for clarity](https://learn.microsoft.com/en-ca/dotnet/fundamentals/code-analysis/quality-rules/ca1307)
- [CA1711: Identifiers should not have incorrect suffix](https://learn.microsoft.com/en-ca/dotnet/fundamentals/code-analysis/quality-rules/ca1711)
- [CA1716: Identifiers should not match keywords](https://learn.microsoft.com/en-ca/dotnet/fundamentals/code-analysis/quality-rules/ca1716)
- [CA1812: Avoid uninstantiated internal classes](https://learn.microsoft.com/en-ca/dotnet/fundamentals/code-analysis/quality-rules/ca1812)

I also did a minor cleanup of small warnings. Each step was done as a separate commit to facilitate the code review.