### PR TITLE
Optimize RequestHandlerWrapperImpl object construction in Mediator's Send Methods

### DIFF
--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -68,7 +68,14 @@ public class Mediator : IMediator
 
         var handler = (RequestHandlerWrapper) _requestHandlers.GetOrAdd(request.GetType(), static requestType =>
         {
-            return new RequestHandlerWrapperImpl<TRequest>() ?? throw new InvalidOperationException($"Could not create wrapper type for {requestType}");
+            try
+            {
+                return new RequestHandlerWrapperImpl<TRequest>();
+            }
+            catch (Exception)
+            {
+                throw new InvalidOperationException($"Could not create wrapper type for {requestType}");
+            }
         });
 
         return handler.Handle(request, _serviceProvider, cancellationToken);

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -68,14 +68,7 @@ public class Mediator : IMediator
 
         var handler = (RequestHandlerWrapper) _requestHandlers.GetOrAdd(request.GetType(), static requestType =>
         {
-            try
-            {
-                return new RequestHandlerWrapperImpl<TRequest>();
-            }
-            catch (Exception)
-            {
-                throw new InvalidOperationException($"Could not create wrapper type for {requestType}");
-            }
+            return new RequestHandlerWrapperImpl<TRequest>() ?? throw new InvalidOperationException($"Could not create wrapper type for {requestType}");
         });
 
         return handler.Handle(request, _serviceProvider, cancellationToken);

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -101,9 +101,9 @@ public class Mediator : IMediator
                 var responseType = requestInterfaceType.GetGenericArguments()[0];
                 wrapperType = typeof(RequestHandlerWrapperImpl<,>).MakeGenericType(requestType, responseType);
             }
-
-            var wrapper = Activator.CreateInstance(wrapperType) ?? throw new InvalidOperationException($"Could not create wrapper for type {requestType}");
-            return (RequestHandlerBase) wrapper;
+            var ctor = wrapperType.GetConstructors().First();
+            var wrapper = Expression.Lambda<Func<RequestHandlerBase>>(Expression.New(ctor)).Compile() ?? throw new InvalidOperationException($"Could not create wrapper for type {requestType}");
+            return wrapper();
         });
 
         // call via dynamic dispatch to avoid calling through reflection for performance reasons
@@ -188,8 +188,9 @@ public class Mediator : IMediator
 
             var responseType = requestInterfaceType.GetGenericArguments()[0];
             var wrapperType = typeof(StreamRequestHandlerWrapperImpl<,>).MakeGenericType(requestType, responseType);
-            var wrapper = Activator.CreateInstance(wrapperType) ?? throw new InvalidOperationException($"Could not create wrapper for type {requestType}");
-            return (StreamRequestHandlerBase) wrapper;
+            var ctor = wrapperType.GetConstructors().First();
+            var wrapper = Expression.Lambda<Func<StreamRequestHandlerBase>>(Expression.New(ctor)).Compile() ?? throw new InvalidOperationException($"Could not create wrapper for type {requestType}");
+            return wrapper();
         });
 
         var items = handler.Handle(request, _serviceProvider, cancellationToken);

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -143,9 +143,9 @@ public class Mediator : IMediator
     {
         var handler = _notificationHandlers.GetOrAdd(notification.GetType(), static notificationType =>
         {
-            var wrapperType = typeof(NotificationHandlerWrapperImpl<>).MakeGenericType(notificationType);
-            var wrapper = Activator.CreateInstance(wrapperType) ?? throw new InvalidOperationException($"Could not create wrapper for type {notificationType}");
-            return (NotificationHandlerWrapper) wrapper;
+            var wrapperType = typeof(NotificationHandlerWrapperImpl<>).MakeGenericType(notificationType); var ctor = wrapperType.GetConstructors().First();
+            var wrapper = Expression.Lambda<Func<NotificationHandlerWrapper>>(Expression.New(ctor)).Compile() ?? throw new InvalidOperationException($"Could not create wrapper for type {notificationType}");
+            return wrapper();
         });
 
         return handler.Handle(notification, _serviceProvider, PublishCore, cancellationToken);
@@ -161,8 +161,9 @@ public class Mediator : IMediator
         var streamHandler = (StreamRequestHandlerWrapper<TResponse>) _streamRequestHandlers.GetOrAdd(request.GetType(), static requestType =>
         {
             var wrapperType = typeof(StreamRequestHandlerWrapperImpl<,>).MakeGenericType(requestType, typeof(TResponse));
-            var wrapper = Activator.CreateInstance(wrapperType) ?? throw new InvalidOperationException($"Could not create wrapper for type {requestType}");
-            return (StreamRequestHandlerBase) wrapper;
+            var ctor = wrapperType.GetConstructors().First();
+            var wrapper = Expression.Lambda<Func<StreamRequestHandlerWrapper<TResponse>>>(Expression.New(ctor)).Compile() ?? throw new InvalidOperationException($"Could not create wrapper type for {requestType}");
+            return wrapper();
         });
 
         var items = streamHandler.Handle(request, _serviceProvider, cancellationToken);

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -64,16 +64,14 @@ public class Mediator : IMediator
             throw new ArgumentNullException(nameof(request));
         }
 
-        var handler = (RequestHandlerWrapper)_requestHandlers.GetOrAdd(request.GetType(), static requestType =>
+        var handler = (RequestHandlerWrapper) _requestHandlers.GetOrAdd(request.GetType(), static requestType =>
         {
-            var wrapperType = typeof(RequestHandlerWrapperImpl<>).MakeGenericType(requestType);
-            var wrapper = Activator.CreateInstance(wrapperType) ?? throw new InvalidOperationException($"Could not create wrapper type for {requestType}");
-            return (RequestHandlerBase)wrapper;
+            return new RequestHandlerWrapperImpl<TRequest>() ?? throw new InvalidOperationException($"Could not create wrapper type for {typeof(TRequest)}");
         });
 
         return handler.Handle(request, _serviceProvider, cancellationToken);
     }
-
+    
     public Task<object?> Send(object request, CancellationToken cancellationToken = default)
     {
         if (request == null)

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Wrappers;
@@ -26,7 +25,7 @@ public class Mediator : IMediator
     /// Initializes a new instance of the <see cref="Mediator"/> class.
     /// </summary>
     /// <param name="serviceProvider">Service provider. Can be a scoped or root provider</param>
-    public Mediator(IServiceProvider serviceProvider)
+    public Mediator(IServiceProvider serviceProvider) 
         : this(serviceProvider, new ForeachAwaitPublisher()) { }
 
     /// <summary>
@@ -47,12 +46,11 @@ public class Mediator : IMediator
             throw new ArgumentNullException(nameof(request));
         }
 
-        var handler = (RequestHandlerWrapper<TResponse>) _requestHandlers.GetOrAdd(request.GetType(), static requestType =>
+        var handler = (RequestHandlerWrapper<TResponse>)_requestHandlers.GetOrAdd(request.GetType(), static requestType =>
         {
             var wrapperType = typeof(RequestHandlerWrapperImpl<,>).MakeGenericType(requestType, typeof(TResponse));
-            var ctor = wrapperType.GetConstructors().First();
-            var expression = Expression.Lambda<Func<RequestHandlerWrapper<TResponse>>>(Expression.New(ctor)).Compile() ?? throw new InvalidOperationException($"Could not create wrapper type for {requestType}");
-            return expression();
+            var wrapper = Activator.CreateInstance(wrapperType) ?? throw new InvalidOperationException($"Could not create wrapper type for {requestType}");
+            return (RequestHandlerBase)wrapper;
         });
 
         return handler.Handle(request, _serviceProvider, cancellationToken);
@@ -66,16 +64,11 @@ public class Mediator : IMediator
             throw new ArgumentNullException(nameof(request));
         }
 
-        var handler = (RequestHandlerWrapper) _requestHandlers.GetOrAdd(request.GetType(), static requestType =>
+        var handler = (RequestHandlerWrapper)_requestHandlers.GetOrAdd(request.GetType(), static requestType =>
         {
-            try
-            {
-                return new RequestHandlerWrapperImpl<TRequest>();
-            }
-            catch (Exception)
-            {
-                throw new InvalidOperationException($"Could not create wrapper type for {requestType}");
-            }
+            var wrapperType = typeof(RequestHandlerWrapperImpl<>).MakeGenericType(requestType);
+            var wrapper = Activator.CreateInstance(wrapperType) ?? throw new InvalidOperationException($"Could not create wrapper type for {requestType}");
+            return (RequestHandlerBase)wrapper;
         });
 
         return handler.Handle(request, _serviceProvider, cancellationToken);
@@ -110,7 +103,7 @@ public class Mediator : IMediator
             }
 
             var wrapper = Activator.CreateInstance(wrapperType) ?? throw new InvalidOperationException($"Could not create wrapper for type {requestType}");
-            return (RequestHandlerBase) wrapper;
+            return (RequestHandlerBase)wrapper;
         });
 
         // call via dynamic dispatch to avoid calling through reflection for performance reasons
@@ -143,7 +136,7 @@ public class Mediator : IMediator
     /// <param name="notification">The notification being published</param>
     /// <param name="cancellationToken">The cancellation token</param>
     /// <returns>A task representing invoking all handlers</returns>
-    protected virtual Task PublishCore(IEnumerable<NotificationHandlerExecutor> handlerExecutors, INotification notification, CancellationToken cancellationToken)
+    protected virtual Task PublishCore(IEnumerable<NotificationHandlerExecutor> handlerExecutors, INotification notification, CancellationToken cancellationToken) 
         => _publisher.Publish(handlerExecutors, notification, cancellationToken);
 
     private Task PublishNotification(INotification notification, CancellationToken cancellationToken = default)
@@ -152,11 +145,12 @@ public class Mediator : IMediator
         {
             var wrapperType = typeof(NotificationHandlerWrapperImpl<>).MakeGenericType(notificationType);
             var wrapper = Activator.CreateInstance(wrapperType) ?? throw new InvalidOperationException($"Could not create wrapper for type {notificationType}");
-            return (NotificationHandlerWrapper) wrapper;
+            return (NotificationHandlerWrapper)wrapper;
         });
 
         return handler.Handle(notification, _serviceProvider, PublishCore, cancellationToken);
     }
+
 
     public IAsyncEnumerable<TResponse> CreateStream<TResponse>(IStreamRequest<TResponse> request, CancellationToken cancellationToken = default)
     {
@@ -165,17 +159,18 @@ public class Mediator : IMediator
             throw new ArgumentNullException(nameof(request));
         }
 
-        var streamHandler = (StreamRequestHandlerWrapper<TResponse>) _streamRequestHandlers.GetOrAdd(request.GetType(), static requestType =>
+        var streamHandler = (StreamRequestHandlerWrapper<TResponse>)_streamRequestHandlers.GetOrAdd(request.GetType(), static requestType =>
         {
             var wrapperType = typeof(StreamRequestHandlerWrapperImpl<,>).MakeGenericType(requestType, typeof(TResponse));
             var wrapper = Activator.CreateInstance(wrapperType) ?? throw new InvalidOperationException($"Could not create wrapper for type {requestType}");
-            return (StreamRequestHandlerBase) wrapper;
+            return (StreamRequestHandlerBase)wrapper;
         });
 
         var items = streamHandler.Handle(request, _serviceProvider, cancellationToken);
 
         return items;
     }
+
 
     public IAsyncEnumerable<object?> CreateStream(object request, CancellationToken cancellationToken = default)
     {
@@ -195,7 +190,7 @@ public class Mediator : IMediator
             var responseType = requestInterfaceType.GetGenericArguments()[0];
             var wrapperType = typeof(StreamRequestHandlerWrapperImpl<,>).MakeGenericType(requestType, responseType);
             var wrapper = Activator.CreateInstance(wrapperType) ?? throw new InvalidOperationException($"Could not create wrapper for type {requestType}");
-            return (StreamRequestHandlerBase) wrapper;
+            return (StreamRequestHandlerBase)wrapper;
         });
 
         var items = handler.Handle(request, _serviceProvider, cancellationToken);

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -101,9 +101,9 @@ public class Mediator : IMediator
                 var responseType = requestInterfaceType.GetGenericArguments()[0];
                 wrapperType = typeof(RequestHandlerWrapperImpl<,>).MakeGenericType(requestType, responseType);
             }
-            var ctor = wrapperType.GetConstructors().First();
-            var wrapper = Expression.Lambda<Func<RequestHandlerBase>>(Expression.New(ctor)).Compile() ?? throw new InvalidOperationException($"Could not create wrapper for type {requestType}");
-            return wrapper();
+
+            var wrapper = Activator.CreateInstance(wrapperType) ?? throw new InvalidOperationException($"Could not create wrapper for type {requestType}");
+            return (RequestHandlerBase) wrapper;
         });
 
         // call via dynamic dispatch to avoid calling through reflection for performance reasons
@@ -188,9 +188,8 @@ public class Mediator : IMediator
 
             var responseType = requestInterfaceType.GetGenericArguments()[0];
             var wrapperType = typeof(StreamRequestHandlerWrapperImpl<,>).MakeGenericType(requestType, responseType);
-            var ctor = wrapperType.GetConstructors().First();
-            var wrapper = Expression.Lambda<Func<StreamRequestHandlerBase>>(Expression.New(ctor)).Compile() ?? throw new InvalidOperationException($"Could not create wrapper for type {requestType}");
-            return wrapper();
+            var wrapper = Activator.CreateInstance(wrapperType) ?? throw new InvalidOperationException($"Could not create wrapper for type {requestType}");
+            return (StreamRequestHandlerBase) wrapper;
         });
 
         var items = handler.Handle(request, _serviceProvider, cancellationToken);

--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -150,9 +150,9 @@ public class Mediator : IMediator
     {
         var handler = _notificationHandlers.GetOrAdd(notification.GetType(), static notificationType =>
         {
-            var wrapperType = typeof(NotificationHandlerWrapperImpl<>).MakeGenericType(notificationType); var ctor = wrapperType.GetConstructors().First();
-            var wrapper = Expression.Lambda<Func<NotificationHandlerWrapper>>(Expression.New(ctor)).Compile() ?? throw new InvalidOperationException($"Could not create wrapper for type {notificationType}");
-            return wrapper();
+            var wrapperType = typeof(NotificationHandlerWrapperImpl<>).MakeGenericType(notificationType);
+            var wrapper = Activator.CreateInstance(wrapperType) ?? throw new InvalidOperationException($"Could not create wrapper for type {notificationType}");
+            return (NotificationHandlerWrapper) wrapper;
         });
 
         return handler.Handle(notification, _serviceProvider, PublishCore, cancellationToken);
@@ -168,9 +168,8 @@ public class Mediator : IMediator
         var streamHandler = (StreamRequestHandlerWrapper<TResponse>) _streamRequestHandlers.GetOrAdd(request.GetType(), static requestType =>
         {
             var wrapperType = typeof(StreamRequestHandlerWrapperImpl<,>).MakeGenericType(requestType, typeof(TResponse));
-            var ctor = wrapperType.GetConstructors().First();
-            var wrapper = Expression.Lambda<Func<StreamRequestHandlerWrapper<TResponse>>>(Expression.New(ctor)).Compile() ?? throw new InvalidOperationException($"Could not create wrapper type for {requestType}");
-            return wrapper();
+            var wrapper = Activator.CreateInstance(wrapperType) ?? throw new InvalidOperationException($"Could not create wrapper for type {requestType}");
+            return (StreamRequestHandlerBase) wrapper;
         });
 
         var items = streamHandler.Handle(request, _serviceProvider, cancellationToken);


### PR DESCRIPTION
Remove activator usage from Send methods, and use new and compiled expression for constructing RequestHandlerWrapperImpl objects