### PR TITLE
Fix AutoRegisterRequestProcessors to include all implementations

### DIFF
--- a/src/MediatR/Registration/ServiceRegistrar.cs
+++ b/src/MediatR/Registration/ServiceRegistrar.cs
@@ -23,8 +23,8 @@ public static class ServiceRegistrar
 
         if (configuration.AutoRegisterRequestProcessors)
         {
-            ConnectImplementationsToTypesClosing(typeof(IRequestPreProcessor<>), services, assembliesToScan, false, configuration);
-            ConnectImplementationsToTypesClosing(typeof(IRequestPostProcessor<,>), services, assembliesToScan, false, configuration);
+            ConnectImplementationsToTypesClosing(typeof(IRequestPreProcessor<>), services, assembliesToScan, true, configuration);
+            ConnectImplementationsToTypesClosing(typeof(IRequestPostProcessor<,>), services, assembliesToScan, true, configuration);
         }
 
         var multiOpenInterfaces = new List<Type>

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/PipelineTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/PipelineTests.cs
@@ -847,7 +847,7 @@ public class PipelineTests
     }
 
     [Fact]
-    public void Should_auto_register_processors_when_configured()
+    public void Should_auto_register_processors_when_configured_including_all_concrete_types()
     {
         var cfg = new MediatRServiceConfiguration
         {
@@ -864,8 +864,15 @@ public class PipelineTests
 
         var provider = services.BuildServiceProvider();
 
-        provider.GetServices(typeof(IRequestPreProcessor<Ping>)).Count().ShouldBeGreaterThan(0);
-        provider.GetServices(typeof(IRequestPostProcessor<Ping, Pong>)).Count().ShouldBeGreaterThan(0);
+        var preProcessors = provider.GetServices(typeof(IRequestPreProcessor<Ping>)).ToList();
+        preProcessors.Count.ShouldBeGreaterThan(0);
+        preProcessors.ShouldContain(p => p != null && p.GetType() == typeof(FirstConcretePreProcessor));
+        preProcessors.ShouldContain(p => p != null && p.GetType() == typeof(NextConcretePreProcessor));
+
+        var postProcessors = provider.GetServices(typeof(IRequestPostProcessor<Ping, Pong>)).ToList();
+        postProcessors.Count.ShouldBeGreaterThan(0);
+        postProcessors.ShouldContain(p => p != null && p.GetType() == typeof(FirstConcretePostProcessor));
+        postProcessors.ShouldContain(p => p != null && p.GetType() == typeof(NextConcretePostProcessor));
     }
 
 


### PR DESCRIPTION
This is how this previously worked.  When this option was restored the `addIfAlreadyExists` property was mistakenly set to false.

I have updated the tests and changed this property.