### PR TITLE
Add Support for Generic Handlers

### DIFF
--- a/test/MediatR.Tests/MicrosoftExtensionsDI/AssemblyResolutionTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/AssemblyResolutionTests.cs
@@ -12,7 +12,6 @@ using Xunit;
 public class AssemblyResolutionTests
 {
     private readonly IServiceProvider _provider;
-    private readonly List<ServiceDescriptor> _services;
 
     public AssemblyResolutionTests()
     {
@@ -20,7 +19,6 @@ public class AssemblyResolutionTests
         services.AddSingleton(new Logger());
         services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(Ping).Assembly));
         _provider = services.BuildServiceProvider();
-        _services = services.ToList();
     }
 
     [Fact]

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/AssemblyResolutionTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/AssemblyResolutionTests.cs
@@ -3,6 +3,7 @@
 namespace MediatR.Extensions.Microsoft.DependencyInjection.Tests;
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Shouldly;
@@ -11,6 +12,7 @@ using Xunit;
 public class AssemblyResolutionTests
 {
     private readonly IServiceProvider _provider;
+    private readonly List<ServiceDescriptor> _services;
 
     public AssemblyResolutionTests()
     {
@@ -18,6 +20,7 @@ public class AssemblyResolutionTests
         services.AddSingleton(new Logger());
         services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(Ping).Assembly));
         _provider = services.BuildServiceProvider();
+        _services = services.ToList();
     }
 
     [Fact]
@@ -55,8 +58,32 @@ public class AssemblyResolutionTests
     {
         var services = new ServiceCollection();
 
-        Action registration = () => services.AddMediatR(_ => {});
+        Action registration = () => services.AddMediatR(_ => { });
 
         registration.ShouldThrow<ArgumentException>();
+    }
+
+    [Fact]
+    public void ShouldResolveGenericVoidRequestHandler()
+    {
+        _provider.GetService<IRequestHandler<OpenGenericVoidRequest<ConcreteTypeArgument>>>().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void ShouldResolveGenericReturnTypeRequestHandler()
+    {
+        _provider.GetService<IRequestHandler<OpenGenericReturnTypeRequest<ConcreteTypeArgument>, string>>().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void ShouldResolveGenericPingRequestHandler()
+    {
+        _provider.GetService<IRequestHandler<GenericPing<Pong>, Pong>>().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void ShouldResolveVoidGenericPingRequestHandler()
+    {
+        _provider.GetService<IRequestHandler<VoidGenericPing<Pong>>>().ShouldNotBeNull();
     }
 }

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/Handlers.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/Handlers.cs
@@ -213,6 +213,48 @@ namespace MediatR.Extensions.Microsoft.DependencyInjection.Tests
             throw new System.NotImplementedException();
         }
     }
+
+    interface ITypeArgument { }
+    class ConcreteTypeArgument : ITypeArgument { }
+    class OpenGenericVoidRequest<T> : IRequest
+        where T : class, ITypeArgument
+    { }
+    class OpenGenericVoidRequestHandler<T> : IRequestHandler<OpenGenericVoidRequest<T>>
+        where T : class, ITypeArgument
+    {
+        public Task Handle(OpenGenericVoidRequest<T> request, CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+    class OpenGenericReturnTypeRequest<T> : IRequest<string>
+        where T : class, ITypeArgument
+    { }
+    class OpenGenericReturnTypeRequestHandler<T> : IRequestHandler<OpenGenericReturnTypeRequest<T>, string>
+        where T : class, ITypeArgument
+    {
+        public Task<string> Handle(OpenGenericReturnTypeRequest<T> request, CancellationToken cancellationToken) => Task.FromResult(nameof(request));
+    }
+
+    public class GenericPing<T> : IRequest<T>
+        where T : Pong
+    {
+        public T? Pong { get; set; }
+    }
+
+    public class GenericPingHandler<T> : IRequestHandler<GenericPing<T>, T>
+        where T : Pong
+    {
+        public Task<T> Handle(GenericPing<T> request, CancellationToken cancellationToken) => Task.FromResult(request.Pong!);
+    }
+
+    public class VoidGenericPing<T> : IRequest
+        where T : Pong
+    { }
+
+    public class VoidGenericPingHandler<T> : IRequestHandler<VoidGenericPing<T>>
+        where T : Pong
+    {
+        public Task Handle(VoidGenericPing<T> request, CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
 }
 
 namespace MediatR.Extensions.Microsoft.DependencyInjection.Tests.Included

--- a/test/MediatR.Tests/SendTests.cs
+++ b/test/MediatR.Tests/SendTests.cs
@@ -5,7 +5,6 @@ namespace MediatR.Tests;
 using System;
 using System.Threading.Tasks;
 using Shouldly;
-using Lamar;
 using Xunit;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -109,21 +108,7 @@ public class SendTests
     [Fact]
     public async Task Should_resolve_main_handler()
     {
-        var container = new Container(cfg =>
-        {
-            cfg.Scan(scanner =>
-            {
-                scanner.AssemblyContainingType(typeof(PublishTests));
-                scanner.IncludeNamespaceContainingType<Ping>();
-                scanner.WithDefaultConventions();
-                scanner.AddAllTypesOf(typeof(IRequestHandler<,>));
-            });
-            cfg.For<IMediator>().Use<Mediator>();
-        });
-
-        var mediator = container.GetInstance<IMediator>();
-
-        var response = await mediator.Send(new Ping { Message = "Ping" });
+        var response = await _mediator.Send(new Ping { Message = "Ping" });
 
         response.Message.ShouldBe("Ping Pong");
     }
@@ -131,48 +116,16 @@ public class SendTests
     [Fact]
     public async Task Should_resolve_main_void_handler()
     {
-        var dependency = new Dependency();
+        await _mediator.Send(new VoidPing());
 
-        var container = new Container(cfg =>
-        {
-            cfg.Scan(scanner =>
-            {
-                scanner.AssemblyContainingType(typeof(PublishTests));
-                scanner.IncludeNamespaceContainingType<Ping>();
-                scanner.WithDefaultConventions();
-                scanner.AddAllTypesOf(typeof(IRequestHandler<>));
-                scanner.AddAllTypesOf(typeof(IRequestHandler<,>));
-            });
-            cfg.ForSingletonOf<Dependency>().Use(dependency);
-            cfg.For<IMediator>().Use<Mediator>();
-        });
-
-        var mediator = container.GetInstance<IMediator>();
-
-        await mediator.Send(new VoidPing());
-
-        dependency.Called.ShouldBeTrue();
+        _dependency.Called.ShouldBeTrue();
     }
 
     [Fact]
     public async Task Should_resolve_main_handler_via_dynamic_dispatch()
     {
-        var container = new Container(cfg =>
-        {
-            cfg.Scan(scanner =>
-            {
-                scanner.AssemblyContainingType(typeof(PublishTests));
-                scanner.IncludeNamespaceContainingType<Ping>();
-                scanner.WithDefaultConventions();
-                scanner.AddAllTypesOf(typeof(IRequestHandler<,>));
-            });
-            cfg.For<IMediator>().Use<Mediator>();
-        });
-
-        var mediator = container.GetInstance<IMediator>();
-
         object request = new Ping { Message = "Ping" };
-        var response = await mediator.Send(request);
+        var response = await _mediator.Send(request);
 
         var pong = response.ShouldBeOfType<Pong>();
         pong.Message.ShouldBe("Ping Pong");
@@ -181,50 +134,18 @@ public class SendTests
     [Fact]
     public async Task Should_resolve_main_void_handler_via_dynamic_dispatch()
     {
-        var dependency = new Dependency();
-
-        var container = new Container(cfg =>
-        {
-            cfg.Scan(scanner =>
-            {
-                scanner.AssemblyContainingType(typeof(PublishTests));
-                scanner.IncludeNamespaceContainingType<Ping>();
-                scanner.WithDefaultConventions();
-                scanner.AddAllTypesOf(typeof(IRequestHandler<>));
-                scanner.AddAllTypesOf(typeof(IRequestHandler<,>));
-            });
-            cfg.ForSingletonOf<Dependency>().Use(dependency);
-            cfg.For<IMediator>().Use<Mediator>();
-        });
-
-        var mediator = container.GetInstance<IMediator>();
-
         object request = new VoidPing();
-        var response = await mediator.Send(request);
+        var response = await _mediator.Send(request);
 
         response.ShouldBeOfType<Unit>();
 
-        dependency.Called.ShouldBeTrue();
+        _dependency.Called.ShouldBeTrue();
     }
 
     [Fact]
     public async Task Should_resolve_main_handler_by_specific_interface()
     {
-        var container = new Container(cfg =>
-        {
-            cfg.Scan(scanner =>
-            {
-                scanner.AssemblyContainingType(typeof(PublishTests));
-                scanner.IncludeNamespaceContainingType<Ping>();
-                scanner.WithDefaultConventions();
-                scanner.AddAllTypesOf(typeof(IRequestHandler<,>));
-            });
-            cfg.For<ISender>().Use<Mediator>();
-        });
-
-        var mediator = container.GetInstance<ISender>();
-
-        var response = await mediator.Send(new Ping { Message = "Ping" });
+        var response = await _mediator.Send(new Ping { Message = "Ping" });
 
         response.Message.ShouldBe("Ping Pong");
     }
@@ -232,44 +153,18 @@ public class SendTests
     [Fact]
     public async Task Should_resolve_main_handler_by_given_interface()
     {
-        var dependency = new Dependency();
-        var container = new Container(cfg =>
-        {
-            cfg.Scan(scanner =>
-            {
-                scanner.AssemblyContainingType(typeof(PublishTests));
-                scanner.IncludeNamespaceContainingType<VoidPing>();
-                scanner.WithDefaultConventions();
-                scanner.AddAllTypesOf(typeof(IRequestHandler<>));
-            });
-            cfg.ForSingletonOf<Dependency>().Use(dependency);
-            cfg.For<ISender>().Use<Mediator>();
-        });
-
-        var mediator = container.GetInstance<ISender>();
-
         // wrap requests in an array, so this test won't break on a 'replace with var' refactoring
         var requests = new IRequest[] { new VoidPing() };
-        await mediator.Send(requests[0]);
+        await _mediator.Send(requests[0]);
 
-        dependency.Called.ShouldBeTrue();
+        _dependency.Called.ShouldBeTrue();
     }
 
     [Fact]
-    public async Task Should_raise_execption_on_null_request()
-    {
-        var container = new Container(cfg =>
-        {
-            cfg.For<ISender>().Use<Mediator>();
-        });
-
-        var mediator = container.GetInstance<ISender>();
-
-        await Should.ThrowAsync<ArgumentNullException>(async () => await mediator.Send(default!));
-    }
+    public Task Should_raise_execption_on_null_request() => Should.ThrowAsync<ArgumentNullException>(async () => await _mediator.Send(default!));
 
     [Fact]
-    public async Task Should_resolve_generic_handler_by_given_interface()
+    public async Task Should_resolve_generic_handler()
     {
         var request = new GenericPing<Pong> { Pong = new Pong { Message = "Ping" } };
         var result = await _mediator.Send(request);
@@ -281,7 +176,7 @@ public class SendTests
     }
 
     [Fact]
-    public async Task Should_resolve_generic_void_handler_by_given_interface()
+    public async Task Should_resolve_generic_void_handler()
     {
         var request = new VoidGenericPing<Pong>();
         await _mediator.Send(request);


### PR DESCRIPTION
This PR essentially adds the required logic to register open generic request handlers.

For example:

```csharp
//class to use as generic request type parameter
public class Pong
{
    string Message? { get; set; }
}

//generic request definition
public class GenericPing<T> : IRequest<T>
    where T : Pong 
{
    public T? Pong { get; set; }
}

//generic request handler
public class GenericPingHandler<T> : IRequestHandler<GenericPing<T>, T>
    where T : Pong
{
    public Task<T> Handle(GenericPing<T> request, CancellationToken cancellationToken) => Task.FromResult(request.Pong!);
}

//usage
var pong = _mediator.Send(new GenericPing<Pong>{ Pong = new() { Message = "Ping Pong" } });
Console.WriteLine(pong.Message); //would output "Ping Pong"
```

Huge fan of this library.. With that said.. I find it kind of tedious to have to create separate handlers for each thing, when the code is pretty much copy paste.  Just the entity or type I'm working with has changed.  I think it would be much easier to work with if we could essentially cut some corners by leveraging c# generics.

The only way you can do this without needing a third party library is use assembly scanning and register every single concrete implementation of the generic handlers.  So that is what the code is doing.

I also added some tests to ensure the handlers were being registered.

**Note: this feature doesn't introduce any breaking changes.  The feature is simply opt in by creating handlers like above.. if you don't want to use them then you can keep on using the library the same way without any hiccups.