### PR TITLE
#1014 Pipeline and Services Abstractions

### DIFF
--- a/MediatR.Pipeline/INotificationHandler.cs
+++ b/MediatR.Pipeline/INotificationHandler.cs
@@ -1,0 +1,40 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediatR;
+
+/// <summary>
+/// Defines a handler for a notification
+/// </summary>
+/// <typeparam name="TNotification">The type of notification being handled</typeparam>
+public interface INotificationHandler<in TNotification>
+    where TNotification : INotification
+{
+    /// <summary>
+    /// Handles a notification
+    /// </summary>
+    /// <param name="notification">The notification</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    Task Handle(TNotification notification, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Wrapper class for a synchronous notification handler
+/// </summary>
+/// <typeparam name="TNotification">The notification type</typeparam>
+public abstract class NotificationHandler<TNotification> : INotificationHandler<TNotification>
+    where TNotification : INotification
+{
+    Task INotificationHandler<TNotification>.Handle(TNotification notification, CancellationToken cancellationToken)
+    {
+        Handle(notification);
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Override in a derived class for the handler logic
+    /// </summary>
+    /// <param name="notification">Notification</param>
+    protected abstract void Handle(TNotification notification);
+}

--- a/MediatR.Pipeline/IPipelineBehavior.cs
+++ b/MediatR.Pipeline/IPipelineBehavior.cs
@@ -1,0 +1,30 @@
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediatR;
+
+/// <summary>
+/// Represents an async continuation for the next task to execute in the pipeline
+/// </summary>
+/// <typeparam name="TResponse">Response type</typeparam>
+/// <returns>Awaitable task returning a <typeparamref name="TResponse"/></returns>
+public delegate Task<TResponse> RequestHandlerDelegate<TResponse>();
+
+/// <summary>
+/// Pipeline behavior to surround the inner handler.
+/// Implementations add additional behavior and await the next delegate.
+/// </summary>
+/// <typeparam name="TRequest">Request type</typeparam>
+/// <typeparam name="TResponse">Response type</typeparam>
+public interface IPipelineBehavior<in TRequest, TResponse> where TRequest : notnull
+{
+    /// <summary>
+    /// Pipeline handler. Perform any additional behavior and await the <paramref name="next"/> delegate as necessary
+    /// </summary>
+    /// <param name="request">Incoming request</param>
+    /// <param name="next">Awaitable delegate for the next action in the pipeline. Eventually this delegate represents the handler.</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Awaitable task returning the <typeparamref name="TResponse"/></returns>
+    Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken);
+}

--- a/MediatR.Pipeline/IStreamPipelineBehavior.cs
+++ b/MediatR.Pipeline/IStreamPipelineBehavior.cs
@@ -1,0 +1,30 @@
+﻿
+namespace MediatR;
+
+using System.Collections.Generic;
+using System.Threading;
+
+/// <summary>
+/// Represents an async enumerable continuation for the next task to execute in the pipeline
+/// </summary>
+/// <typeparam name="TResponse">Response type</typeparam>
+/// <returns>Async Enumerable returning a <typeparamref name="TResponse"/></returns>
+public delegate IAsyncEnumerable<TResponse> StreamHandlerDelegate<out TResponse>();
+
+/// <summary>
+/// Stream Pipeline behavior to surround the inner handler.
+/// Implementations add additional behavior and await the next delegate.
+/// </summary>
+/// <typeparam name="TRequest">Request type</typeparam>
+/// <typeparam name="TResponse">Response type</typeparam>
+public interface IStreamPipelineBehavior<in TRequest, TResponse> where TRequest : notnull
+{
+    /// <summary>
+    /// Stream Pipeline handler. Perform any additional behavior and iterate the <paramref name="next"/> delegate as necessary
+    /// </summary>
+    /// <param name="request">Incoming request</param>
+    /// <param name="next">Awaitable delegate for the next action in the pipeline. Eventually this delegate represents the handler.</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Awaitable task returning the <typeparamref name="TResponse"/></returns>
+    IAsyncEnumerable<TResponse> Handle(TRequest request, StreamHandlerDelegate<TResponse> next, CancellationToken cancellationToken);
+}

--- a/MediatR.Pipeline/IStreamRequestHandler.cs
+++ b/MediatR.Pipeline/IStreamRequestHandler.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Threading;
+
+namespace MediatR;
+
+/// <summary>
+/// Defines a handler for a stream request using IAsyncEnumerable as return type.
+/// </summary>
+/// <typeparam name="TRequest">The type of request being handled</typeparam>
+/// <typeparam name="TResponse">The type of response from the handler</typeparam>
+public interface IStreamRequestHandler<in TRequest, out TResponse>
+    where TRequest : IStreamRequest<TResponse>
+{
+    /// <summary>
+    /// Handles a stream request with IAsyncEnumerable as return type.
+    /// </summary>
+    /// <param name="request">The request</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Response from the request</returns>
+    IAsyncEnumerable<TResponse> Handle(TRequest request, CancellationToken cancellationToken);
+}

--- a/MediatR.Pipeline/MediatR.Pipeline.csproj
+++ b/MediatR.Pipeline/MediatR.Pipeline.csproj
@@ -1,0 +1,43 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <Authors>Jimmy Bogard</Authors>
+    <Description>Abstractions package for implementing handlers and behaviors used by the pipeline</Description>
+    <Copyright>Copyright Jimmy Bogard</Copyright>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <Features>strict</Features>
+    <PackageTags>mediator;request;response;queries;commands;notifications</PackageTags>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\MediatR.snk</AssemblyOriginatorKeyFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageIcon>gradient_128x128.png</PackageIcon>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <Deterministic>true</Deterministic>
+    <Version>2.0.1</Version>
+    <RootNamespace>MediatR</RootNamespace>
+
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\assets\logo\gradient_128x128.png" Link="gradient_128x128.png">
+      <PackagePath></PackagePath>
+      <Pack>true</Pack>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MediatR.Contracts" Version="2.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/MediatR.Services/IMediator.cs
+++ b/MediatR.Services/IMediator.cs
@@ -1,0 +1,8 @@
+namespace MediatR;
+
+/// <summary>
+/// Defines a mediator to encapsulate request/response and publishing interaction patterns
+/// </summary>
+public interface IMediator : ISender, IPublisher
+{
+}

--- a/MediatR.Services/INotificationPublisher.cs
+++ b/MediatR.Services/INotificationPublisher.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace MediatR;
+
+public interface INotificationPublisher
+{
+    Task Publish(IEnumerable<NotificationHandlerExecutor> handlerExecutors, INotification notification,
+        CancellationToken cancellationToken);
+}

--- a/MediatR.Services/IPublisher.cs
+++ b/MediatR.Services/IPublisher.cs
@@ -1,0 +1,27 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediatR;
+
+/// <summary>
+/// Publish a notification or event through the mediator pipeline to be handled by multiple handlers.
+/// </summary>
+public interface IPublisher
+{
+    /// <summary>
+    /// Asynchronously send a notification to multiple handlers
+    /// </summary>
+    /// <param name="notification">Notification object</param>
+    /// <param name="cancellationToken">Optional cancellation token</param>
+    /// <returns>A task that represents the publish operation.</returns>
+    Task Publish(object notification, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously send a notification to multiple handlers
+    /// </summary>
+    /// <param name="notification">Notification object</param>
+    /// <param name="cancellationToken">Optional cancellation token</param>
+    /// <returns>A task that represents the publish operation.</returns>
+    Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
+        where TNotification : INotification;
+}

--- a/MediatR.Services/ISender.cs
+++ b/MediatR.Services/ISender.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediatR;
+
+/// <summary>
+/// Send a request through the mediator pipeline to be handled by a single handler.
+/// </summary>
+public interface ISender
+{
+    /// <summary>
+    /// Asynchronously send a request to a single handler
+    /// </summary>
+    /// <typeparam name="TResponse">Response type</typeparam>
+    /// <param name="request">Request object</param>
+    /// <param name="cancellationToken">Optional cancellation token</param>
+    /// <returns>A task that represents the send operation. The task result contains the handler response</returns>
+    Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously send a request to a single handler with no response
+    /// </summary>
+    /// <param name="request">Request object</param>
+    /// <param name="cancellationToken">Optional cancellation token</param>
+    /// <returns>A task that represents the send operation.</returns>
+    Task Send<TRequest>(TRequest request, CancellationToken cancellationToken = default)
+        where TRequest : IRequest;
+
+    /// <summary>
+    /// Asynchronously send an object request to a single handler via dynamic dispatch
+    /// </summary>
+    /// <param name="request">Request object</param>
+    /// <param name="cancellationToken">Optional cancellation token</param>
+    /// <returns>A task that represents the send operation. The task result contains the type erased handler response</returns>
+    Task<object?> Send(object request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Create a stream via a single stream handler
+    /// </summary>
+    /// <typeparam name="TResponse"></typeparam>
+    /// <param name="request"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    IAsyncEnumerable<TResponse> CreateStream<TResponse>(IStreamRequest<TResponse> request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Create a stream via an object request to a stream handler
+    /// </summary>
+    /// <param name="request"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    IAsyncEnumerable<object?> CreateStream(object request, CancellationToken cancellationToken = default);
+}

--- a/MediatR.Services/MediatR.Services.csproj
+++ b/MediatR.Services/MediatR.Services.csproj
@@ -1,0 +1,43 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <Authors>Jimmy Bogard</Authors>
+    <Description>Abstractions package used to interact with MediatR services</Description>
+    <Copyright>Copyright Jimmy Bogard</Copyright>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <Features>strict</Features>
+    <PackageTags>mediator;request;response;queries;commands;notifications</PackageTags>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\MediatR.snk</AssemblyOriginatorKeyFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageIcon>gradient_128x128.png</PackageIcon>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <Deterministic>true</Deterministic>
+    <Version>2.0.1</Version>
+    <RootNamespace>MediatR</RootNamespace>
+
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\assets\logo\gradient_128x128.png" Link="gradient_128x128.png">
+      <PackagePath></PackagePath>
+      <Pack>true</Pack>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MediatR.Contracts" Version="2.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/MediatR.Services/NotificationHandlerExecutor.cs
+++ b/MediatR.Services/NotificationHandlerExecutor.cs
@@ -1,0 +1,7 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediatR;
+
+public record NotificationHandlerExecutor(object HandlerInstance, Func<INotification, CancellationToken, Task> HandlerCallback);

--- a/MediatR.sln
+++ b/MediatR.sln
@@ -47,6 +47,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MediatR.Examples.SimpleInje
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MediatR.Examples.Stashbox", "samples\MediatR.Examples.Stashbox\MediatR.Examples.Stashbox.csproj", "{F9148E20-5856-484C-8410-B515C6C56214}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediatR.Services", "MediatR.Services\MediatR.Services.csproj", "{2E99B1C7-DA23-44F1-8042-37603D4E5EB2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediatR.Pipeline", "MediatR.Pipeline\MediatR.Pipeline.csproj", "{100F635D-67C3-444C-AB4D-20B20540F6D1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -105,6 +109,14 @@ Global
 		{F9148E20-5856-484C-8410-B515C6C56214}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F9148E20-5856-484C-8410-B515C6C56214}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F9148E20-5856-484C-8410-B515C6C56214}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E99B1C7-DA23-44F1-8042-37603D4E5EB2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E99B1C7-DA23-44F1-8042-37603D4E5EB2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E99B1C7-DA23-44F1-8042-37603D4E5EB2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E99B1C7-DA23-44F1-8042-37603D4E5EB2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{100F635D-67C3-444C-AB4D-20B20540F6D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{100F635D-67C3-444C-AB4D-20B20540F6D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{100F635D-67C3-444C-AB4D-20B20540F6D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{100F635D-67C3-444C-AB4D-20B20540F6D1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -123,6 +135,8 @@ Global
 		{004D029A-43E7-47B0-BA74-D0A9F7FC7713} = {E372BF0B-90E8-4DC1-A332-F023095A3C2A}
 		{7CEB57F2-B6DC-4A18-A040-D12555C3D32F} = {E372BF0B-90E8-4DC1-A332-F023095A3C2A}
 		{F9148E20-5856-484C-8410-B515C6C56214} = {E372BF0B-90E8-4DC1-A332-F023095A3C2A}
+		{2E99B1C7-DA23-44F1-8042-37603D4E5EB2} = {6267E2ED-942C-497D-BFC9-B3CE0AFC276F}
+		{100F635D-67C3-444C-AB4D-20B20540F6D1} = {6267E2ED-942C-497D-BFC9-B3CE0AFC276F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D58286E3-878B-4ACB-8E76-F61E708D4339}


### PR DESCRIPTION
closes: #1014 

I have created 2 new abstraction packages/projects: `MediatR.Pipeline` and `MediatR.Services` (feel free to rename them). I have left `MediatR` and `MediatR.Contracts` untouched and have included `MediatR.Contracts` as a NuGet package dependency on the new packages.

Eventually, `MediatR` can include these 2 new NuGet packages as dependencies and remove the duplicate interfaces from its source code.

I left out the interfaces used in `MediatR` inside the `MediatR.Pipeline` namespace because they're more coupled with pipeline-related concepts and I don't think these are being requested from the initial issues raised. If more work is required, let me know or feel free to update this PR.

---

The reason for these additions is to allow for more architectural flexibility when using MediatR (which also solves my initial issue). For more information, please refer to the [linked issue](https://github.com/jbogard/MediatR/issues/1014).

**TL;DR:** I can have one project depend on the `MediatR.Pipeline` NuGet package to store implementations of handlers and behaviors without being allowed to use services to send nested requests, and I can have another project depending on the `MediatR.Services` NuGet package for sending requests without implementing handlers.