### PR TITLE
Set TargetFrameworks solely to "netstandard2.0"

### DIFF
--- a/src/MediatR/MediatR.csproj
+++ b/src/MediatR/MediatR.csproj
@@ -4,7 +4,7 @@
     <Authors>Jimmy Bogard</Authors>
     <Description>Simple, unambitious mediator implementation in .NET</Description>
     <Copyright>Copyright Jimmy Bogard</Copyright>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <Features>strict</Features>
     <PackageTags>mediator;request;response;queries;commands;notifications</PackageTags>


### PR DESCRIPTION
Changed the `<TargetFrameworks>` from `netstandard2.0;net6.0` to just `netstandard2.0`. It shouldn't affect users since `netstandard2.0` works with .NET 6.