### PR TITLE
Add Support For Generic Handlers With Multiple Generic Type Parameters

### DIFF
--- a/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
+++ b/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
@@ -70,6 +70,26 @@ public class MediatRServiceConfiguration
     public bool AutoRegisterRequestProcessors { get; set; }
 
     /// <summary>
+    /// Configure the maximum number of type parameters that a generic request handler can have. To Disable this constraint, set the value to 0.
+    /// </summary>
+    public int MaxGenericTypeParameters { get; set; } = 10;
+
+    /// <summary>
+    /// Configure the maximum number of types that can close a generic request type parameter constraint.  To Disable this constraint, set the value to 0.
+    /// </summary>
+    public int MaxTypesClosing { get; set; } = 100;
+
+    /// <summary>
+    /// Configure the Maximum Amount of Generic RequestHandler Types MediatR will try to register.  To Disable this constraint, set the value to 0.
+    /// </summary>
+    public int MaxGenericTypeRegistrations { get; set; } = 125000;
+
+    /// <summary>
+    /// Configure the Timeout in Milliseconds that the GenericHandler Registration Process will exit with error.  To Disable this constraint, set the value to 0.
+    /// </summary>
+    public int RegistrationTimeout { get; set; } = 15000;
+
+    /// <summary>
     /// Register various handlers from assembly containing given type
     /// </summary>
     /// <typeparam name="T">Type from assembly to scan</typeparam>

--- a/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
+++ b/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
@@ -90,6 +90,11 @@ public class MediatRServiceConfiguration
     public int RegistrationTimeout { get; set; } = 15000;
 
     /// <summary>
+    /// Flag that controlls whether MediatR will attempt to register handlers that containg generic type parameters.
+    /// </summary>
+    public bool RegisterGenericHandlers { get; set; } = true;
+
+    /// <summary>
     /// Register various handlers from assembly containing given type
     /// </summary>
     /// <typeparam name="T">Type from assembly to scan</typeparam>

--- a/src/MediatR/MicrosoftExtensionsDI/ServiceCollectionExtensions.cs
+++ b/src/MediatR/MicrosoftExtensionsDI/ServiceCollectionExtensions.cs
@@ -47,7 +47,9 @@ public static class ServiceCollectionExtensions
             throw new ArgumentException("No assemblies found to scan. Supply at least one assembly to scan for handlers.");
         }
 
-        ServiceRegistrar.AddMediatRClasses(services, configuration);
+        ServiceRegistrar.SetGenericRequestHandlerRegistrationLimitations(configuration);
+
+        ServiceRegistrar.AddMediatRClassesWithTimeout(services, configuration);
 
         ServiceRegistrar.AddRequiredServices(services, configuration);
 

--- a/src/MediatR/Registration/ServiceRegistrar.cs
+++ b/src/MediatR/Registration/ServiceRegistrar.cs
@@ -103,6 +103,7 @@ public static class ServiceRegistrar
 
         var types = assembliesToScan
             .SelectMany(a => a.DefinedTypes)
+            .Where(t => !t.ContainsGenericParameters || configuration.RegisterGenericHandlers)
             .Where(t => t.IsConcrete() && t.FindInterfacesThatClose(openRequestInterface).Any())
             .Where(configuration.TypeEvaluator)
             .ToList();        

--- a/src/MediatR/Registration/ServiceRegistrar.cs
+++ b/src/MediatR/Registration/ServiceRegistrar.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using MediatR.Pipeline;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -10,12 +11,41 @@ namespace MediatR.Registration;
 
 public static class ServiceRegistrar
 {
-    public static void AddMediatRClasses(IServiceCollection services, MediatRServiceConfiguration configuration)
+    private static int MaxGenericTypeParameters;
+    private static int MaxTypesClosing;
+    private static int MaxGenericTypeRegistrations;
+    private static int RegistrationTimeout; 
+
+    public static void SetGenericRequestHandlerRegistrationLimitations(MediatRServiceConfiguration configuration)
     {
+        MaxGenericTypeParameters = configuration.MaxGenericTypeParameters;
+        MaxTypesClosing = configuration.MaxTypesClosing;
+        MaxGenericTypeRegistrations = configuration.MaxGenericTypeRegistrations;
+        RegistrationTimeout = configuration.RegistrationTimeout;
+    }
+
+    public static void AddMediatRClassesWithTimeout(IServiceCollection services, MediatRServiceConfiguration configuration)
+    {
+        using(var cts = new CancellationTokenSource(RegistrationTimeout))
+        {
+            try
+            {
+                AddMediatRClasses(services, configuration, cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                throw new TimeoutException("The generic handler registration process timed out.");
+            }
+        }
+    }
+
+    public static void AddMediatRClasses(IServiceCollection services, MediatRServiceConfiguration configuration, CancellationToken cancellationToken = default)
+    {   
+
         var assembliesToScan = configuration.AssembliesToRegister.Distinct().ToArray();
 
-        ConnectImplementationsToTypesClosing(typeof(IRequestHandler<,>), services, assembliesToScan, false, configuration);
-        ConnectImplementationsToTypesClosing(typeof(IRequestHandler<>), services, assembliesToScan, false, configuration);
+        ConnectImplementationsToTypesClosing(typeof(IRequestHandler<,>), services, assembliesToScan, false, configuration, cancellationToken);
+        ConnectImplementationsToTypesClosing(typeof(IRequestHandler<>), services, assembliesToScan, false, configuration, cancellationToken);
         ConnectImplementationsToTypesClosing(typeof(INotificationHandler<>), services, assembliesToScan, true, configuration);
         ConnectImplementationsToTypesClosing(typeof(IStreamRequestHandler<,>), services, assembliesToScan, false, configuration);
         ConnectImplementationsToTypesClosing(typeof(IRequestExceptionHandler<,,>), services, assembliesToScan, true, configuration);
@@ -63,7 +93,8 @@ public static class ServiceRegistrar
         IServiceCollection services,
         IEnumerable<Assembly> assembliesToScan,
         bool addIfAlreadyExists,
-        MediatRServiceConfiguration configuration)
+        MediatRServiceConfiguration configuration,
+        CancellationToken cancellationToken = default)
     {
         var concretions = new List<Type>();
         var interfaces = new List<Type>();
@@ -74,7 +105,7 @@ public static class ServiceRegistrar
             .SelectMany(a => a.DefinedTypes)
             .Where(t => t.IsConcrete() && t.FindInterfacesThatClose(openRequestInterface).Any())
             .Where(configuration.TypeEvaluator)
-            .ToList();
+            .ToList();        
 
         foreach (var type in types)
         {
@@ -131,7 +162,7 @@ public static class ServiceRegistrar
         foreach (var @interface in genericInterfaces)
         {
             var exactMatches = genericConcretions.Where(x => x.CanBeCastTo(@interface)).ToList();
-            AddAllConcretionsThatClose(@interface, exactMatches, services, assembliesToScan);
+            AddAllConcretionsThatClose(@interface, exactMatches, services, assembliesToScan, cancellationToken);
         }
     }
 
@@ -174,7 +205,7 @@ public static class ServiceRegistrar
 
     private static (Type Service, Type Implementation) GetConcreteRegistrationTypes(Type openRequestHandlerInterface, Type concreteGenericTRequest, Type openRequestHandlerImplementation)
     {
-        var closingType = concreteGenericTRequest.GetGenericArguments().First();
+        var closingTypes = concreteGenericTRequest.GetGenericArguments();
 
         var concreteTResponse = concreteGenericTRequest.GetInterfaces()
             .FirstOrDefault(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IRequest<>))
@@ -187,17 +218,25 @@ public static class ServiceRegistrar
             typeDefinition.MakeGenericType(concreteGenericTRequest, concreteTResponse) :
             typeDefinition.MakeGenericType(concreteGenericTRequest);
 
-        return (serviceType, openRequestHandlerImplementation.MakeGenericType(closingType));
+        return (serviceType, openRequestHandlerImplementation.MakeGenericType(closingTypes));
     }
 
-    private static List<Type>? GetConcreteRequestTypes(Type openRequestHandlerInterface, Type openRequestHandlerImplementation, IEnumerable<Assembly> assembliesToScan)
+    private static List<Type>? GetConcreteRequestTypes(Type openRequestHandlerInterface, Type openRequestHandlerImplementation, IEnumerable<Assembly> assembliesToScan, CancellationToken cancellationToken)
     {
-        var constraints = openRequestHandlerImplementation.GetGenericArguments().First().GetGenericParameterConstraints();
-
-        var typesThatCanClose = assembliesToScan
-            .SelectMany(assembly => assembly.GetTypes())
-            .Where(type => type.IsClass && !type.IsAbstract && constraints.All(constraint => constraint.IsAssignableFrom(type)))
+        //request generic type constraints       
+        var constraintsForEachParameter = openRequestHandlerImplementation
+            .GetGenericArguments()
+            .Select(x => x.GetGenericParameterConstraints())
             .ToList();
+
+        if (constraintsForEachParameter.Count > 2 && constraintsForEachParameter.Any(constraints => !constraints.Where(x => x.IsInterface || x.IsClass).Any()))
+            throw new ArgumentException($"Error registering the generic handler type: {openRequestHandlerImplementation.FullName}. When registering generic requests with more than two type parameters, each type parameter must have at least one constraint of type interface or class.");
+
+        var typesThatCanCloseForEachParameter = constraintsForEachParameter
+            .Select(constraints => assembliesToScan
+                .SelectMany(assembly => assembly.GetTypes())
+                .Where(type => type.IsClass && !type.IsAbstract && constraints.All(constraint => constraint.IsAssignableFrom(type))).ToList()
+            ).ToList();
 
         var requestType = openRequestHandlerInterface.GenericTypeArguments.First();
 
@@ -205,15 +244,64 @@ public static class ServiceRegistrar
             return null;
 
         var requestGenericTypeDefinition = requestType.GetGenericTypeDefinition();
+              
+        var combinations = GenerateCombinations(requestType, typesThatCanCloseForEachParameter, 0, cancellationToken);
 
-        return typesThatCanClose.Select(type => requestGenericTypeDefinition.MakeGenericType(type)).ToList();
+        return combinations.Select(types => requestGenericTypeDefinition.MakeGenericType(types.ToArray())).ToList();
     }
 
-    private static void AddAllConcretionsThatClose(Type openRequestInterface, List<Type> concretions, IServiceCollection services, IEnumerable<Assembly> assembliesToScan)
+    // Method to generate combinations recursively
+    public static List<List<Type>> GenerateCombinations(Type requestType, List<List<Type>> lists, int depth = 0, CancellationToken cancellationToken = default)
+    {
+        if (depth == 0)
+        {
+            // Initial checks
+            if (MaxGenericTypeParameters > 0 && lists.Count > MaxGenericTypeParameters)
+                throw new ArgumentException($"Error registering the generic type: {requestType.FullName}. The number of generic type parameters exceeds the maximum allowed ({MaxGenericTypeParameters}).");
+
+            foreach (var list in lists)
+            {
+                if (MaxTypesClosing > 0 && list.Count > MaxTypesClosing)
+                    throw new ArgumentException($"Error registering the generic type: {requestType.FullName}. One of the generic type parameter's count of types that can close exceeds the maximum length allowed ({MaxTypesClosing}).");
+            }
+
+            // Calculate the total number of combinations
+            long totalCombinations = 1;
+            foreach (var list in lists)
+            {
+                totalCombinations *= list.Count;
+                if (MaxGenericTypeParameters > 0 && totalCombinations > MaxGenericTypeRegistrations)
+                    throw new ArgumentException($"Error registering the generic type: {requestType.FullName}. The total number of generic type registrations exceeds the maximum allowed ({MaxGenericTypeRegistrations}).");
+            }
+        }
+
+        if (depth >= lists.Count)
+            return new List<List<Type>> { new List<Type>() };
+       
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var currentList = lists[depth];
+        var childCombinations = GenerateCombinations(requestType, lists, depth + 1, cancellationToken);
+        var combinations = new List<List<Type>>();
+
+        foreach (var item in currentList)
+        {
+            foreach (var childCombination in childCombinations)
+            {
+                var currentCombination = new List<Type> { item };
+                currentCombination.AddRange(childCombination);
+                combinations.Add(currentCombination);
+            }
+        }
+
+        return combinations;
+    }
+
+    private static void AddAllConcretionsThatClose(Type openRequestInterface, List<Type> concretions, IServiceCollection services, IEnumerable<Assembly> assembliesToScan, CancellationToken cancellationToken)
     {
         foreach (var concretion in concretions)
-        {
-            var concreteRequests = GetConcreteRequestTypes(openRequestInterface, concretion, assembliesToScan);
+        {   
+            var concreteRequests = GetConcreteRequestTypes(openRequestInterface, concretion, assembliesToScan, cancellationToken);
 
             if (concreteRequests is null)
                 continue;
@@ -223,6 +311,7 @@ public static class ServiceRegistrar
 
             foreach (var (Service, Implementation) in registrationTypes)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 services.AddTransient(Service, Implementation);
             }
         }

--- a/test/MediatR.Tests/GenericRequestHandlerTests.cs
+++ b/test/MediatR.Tests/GenericRequestHandlerTests.cs
@@ -1,0 +1,190 @@
+﻿using MediatR.Extensions.Microsoft.DependencyInjection.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using System.Reflection.PortableExecutable;
+using MediatR.Tests.MicrosoftExtensionsDI;
+
+namespace MediatR.Tests
+{
+    public class GenericRequestHandlerTests : BaseGenericRequestHandlerTests
+    {
+
+        [Theory]
+        [InlineData(9, 3, 3)]
+        [InlineData(10, 4, 4)]
+        [InlineData(1, 1, 1)]
+        [InlineData(50, 3, 3)]
+        public void ShouldResolveAllCombinationsOfGenericHandler(int numberOfClasses, int numberOfInterfaces, int numberOfTypeParameters)
+        {
+            var services = new ServiceCollection();
+
+            var dynamicAssembly = GenerateCombinationsTestAssembly(numberOfClasses, numberOfInterfaces, numberOfTypeParameters);
+
+            services.AddMediatR(cfg =>
+            {
+                cfg.RegisterServicesFromAssemblies(dynamicAssembly);
+            });
+
+            var provider = services.BuildServiceProvider();
+
+            var dynamicRequestType = dynamicAssembly.GetType("DynamicRequest")!;
+
+            int expectedCombinations = CalculateTotalCombinations(numberOfClasses, numberOfInterfaces, numberOfTypeParameters);
+
+            var testClasses = Enumerable.Range(1, numberOfClasses)
+                .Select(i => dynamicAssembly.GetType($"TestClass{i}")!)
+                .ToArray();
+
+            var combinations = GenerateCombinations(testClasses, numberOfInterfaces);          
+
+            foreach (var combination in combinations)
+            {
+                var concreteRequestType = dynamicRequestType.MakeGenericType(combination);
+                var requestHandlerInterface = typeof(IRequestHandler<>).MakeGenericType(concreteRequestType);
+
+                var handler = provider.GetService(requestHandlerInterface);
+                handler.ShouldNotBeNull($"Handler for {concreteRequestType} should not be null");
+            }            
+        }
+
+        [Theory]
+        [InlineData(9, 3, 3)]
+        [InlineData(10, 4, 4)]
+        [InlineData(1, 1, 1)]
+        [InlineData(50, 3, 3)]
+        public void ShouldRegisterTheCorrectAmountOfHandlers(int numberOfClasses, int numberOfInterfaces, int numberOfTypeParameters)
+        {  
+            var dynamicAssembly = GenerateCombinationsTestAssembly(numberOfClasses, numberOfInterfaces, numberOfTypeParameters);          
+            int expectedCombinations = CalculateTotalCombinations(numberOfClasses, numberOfInterfaces, numberOfTypeParameters);
+            var testClasses = Enumerable.Range(1, numberOfClasses)
+               .Select(i => dynamicAssembly.GetType($"TestClass{i}")!)
+               .ToArray();
+            var combinations = GenerateCombinations(testClasses, numberOfInterfaces);
+            combinations.Count.ShouldBe(expectedCombinations, $"Should have tested all {expectedCombinations} combinations");
+        }
+
+        [Theory]
+        [InlineData(9, 3, 3)]
+        [InlineData(10, 4, 4)]
+        [InlineData(1, 1, 1)]
+        [InlineData(50, 3, 3)]
+        public void ShouldNotRegisterDuplicateHandlers(int numberOfClasses, int numberOfInterfaces, int numberOfTypeParameters)
+        {
+            var dynamicAssembly = GenerateCombinationsTestAssembly(numberOfClasses, numberOfInterfaces, numberOfTypeParameters);
+            int expectedCombinations = CalculateTotalCombinations(numberOfClasses, numberOfInterfaces, numberOfTypeParameters);
+            var testClasses = Enumerable.Range(1, numberOfClasses)
+               .Select(i => dynamicAssembly.GetType($"TestClass{i}")!)
+               .ToArray();
+            var combinations = GenerateCombinations(testClasses, numberOfInterfaces);
+            var hasDuplicates = combinations
+              .Select(x => string.Join(", ", x.Select(y => y.Name)))
+              .GroupBy(x => x)
+              .Any(g => g.Count() > 1);
+
+            hasDuplicates.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenRegisterningHandlersWithNoConstraints()
+        {
+            IServiceCollection services = new ServiceCollection();
+            services.AddSingleton(new Logger());
+
+            var assembly = GenerateMissingConstraintsAssembly();
+
+            Should.Throw<ArgumentException>(() =>
+            {
+                services.AddMediatR(cfg =>
+                {
+                    cfg.RegisterServicesFromAssembly(assembly);
+                });
+            })
+            .Message.ShouldContain("When registering generic requests with more than two type parameters, each type parameter must have at least one constraint of type interface or class.");
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenTypesClosingExceedsMaximum()
+        {
+            IServiceCollection services = new ServiceCollection();
+            services.AddSingleton(new Logger());
+
+            var assembly = GenerateTypesClosingExceedsMaximumAssembly();
+
+            Should.Throw<ArgumentException>(() =>
+            {
+                services.AddMediatR(cfg =>
+                {
+                    cfg.RegisterServicesFromAssembly(assembly);
+                });
+            })
+            .Message.ShouldContain("One of the generic type parameter's count of types that can close exceeds the maximum length allowed");
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenGenericHandlerRegistrationsExceedsMaximum()
+        {
+            IServiceCollection services = new ServiceCollection();
+            services.AddSingleton(new Logger());
+
+            var assembly = GenerateHandlerRegistrationsExceedsMaximumAssembly();
+
+            Should.Throw<ArgumentException>(() =>
+            {
+                services.AddMediatR(cfg =>
+                {
+                    cfg.RegisterServicesFromAssembly(assembly);
+                });
+            })
+            .Message.ShouldContain("The total number of generic type registrations exceeds the maximum allowed");
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenGenericTypeParametersExceedsMaximum()
+        {
+            IServiceCollection services = new ServiceCollection();
+            services.AddSingleton(new Logger());
+
+            var assembly = GenerateGenericTypeParametersExceedsMaximumAssembly();
+
+            Should.Throw<ArgumentException>(() =>
+            {
+                services.AddMediatR(cfg =>
+                {
+                    cfg.RegisterServicesFromAssembly(assembly);
+                });
+            })
+            .Message.ShouldContain("The number of generic type parameters exceeds the maximum allowed");
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenTimeoutOccurs()
+        {
+            IServiceCollection services = new ServiceCollection();
+            services.AddSingleton(new Logger());
+
+            var assembly = GenerateTimeoutOccursAssembly();
+
+            Should.Throw<TimeoutException>(() =>
+            {
+                services.AddMediatR(cfg =>
+                {
+                    cfg.MaxGenericTypeParameters = 0;
+                    cfg.MaxGenericTypeRegistrations = 0;
+                    cfg.MaxTypesClosing = 0;
+                    cfg.RegistrationTimeout = 1000;
+                    cfg.RegisterServicesFromAssembly(assembly);
+                });
+            })
+            .Message.ShouldBe("The generic handler registration process timed out.");
+        }
+    }
+}

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/AssemblyResolutionTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/AssemblyResolutionTests.cs
@@ -3,9 +3,7 @@
 namespace MediatR.Extensions.Microsoft.DependencyInjection.Tests;
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Shouldly;
 using Xunit;
 

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/BaseGenericRequestHandlerTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/BaseGenericRequestHandlerTests.cs
@@ -26,6 +26,12 @@ namespace MediatR.Tests.MicrosoftExtensionsDI
         protected static Assembly GenerateTimeoutOccursAssembly() =>
             CreateAssemblyModuleBuilder("TimeOutOccursAssembly", 400, 3, CreateHandlerForTimeoutOccursTest);
 
+        protected static Assembly GenerateOptOutAssembly() =>
+            CreateAssemblyModuleBuilder("OptOutAssembly", 2, 2, CreateHandlerForOptOutTest);
+
+        protected static void CreateHandlerForOptOutTest(ModuleBuilder moduleBuilder) =>
+            CreateRequestHandler(moduleBuilder, "OptOutRequest", 2);
+
         protected static void CreateHandlerForMissingConstraintsTest(ModuleBuilder moduleBuilder) =>
           CreateRequestHandler(moduleBuilder, "MissingConstraintsRequest", 3, 0, false);
 

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/BaseGenericRequestHandlerTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/BaseGenericRequestHandlerTests.cs
@@ -1,0 +1,205 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediatR.Tests.MicrosoftExtensionsDI
+{
+    public abstract class BaseGenericRequestHandlerTests
+    {      
+        
+        protected static Assembly GenerateMissingConstraintsAssembly() =>
+           CreateAssemblyModuleBuilder("MissingConstraintsAssembly", 3, 3, CreateHandlerForMissingConstraintsTest);
+
+        protected static Assembly GenerateTypesClosingExceedsMaximumAssembly() =>
+            CreateAssemblyModuleBuilder("ExceedsMaximumTypesClosingAssembly", 201, 1, CreateHandlerForExceedsMaximumClassesTest);
+
+        protected static Assembly GenerateHandlerRegistrationsExceedsMaximumAssembly() =>
+            CreateAssemblyModuleBuilder("ExceedsMaximumHandlerRegistrationsAssembly", 500, 10, CreateHandlerForExceedsMaximumHandlerRegistrationsTest);
+
+        protected static Assembly GenerateGenericTypeParametersExceedsMaximumAssembly() =>
+            CreateAssemblyModuleBuilder("ExceedsMaximumGenericTypeParametersAssembly", 1, 1, CreateHandlerForExceedsMaximumGenericTypeParametersTest);
+
+        protected static Assembly GenerateTimeoutOccursAssembly() =>
+            CreateAssemblyModuleBuilder("TimeOutOccursAssembly", 400, 3, CreateHandlerForTimeoutOccursTest);
+
+        protected static void CreateHandlerForMissingConstraintsTest(ModuleBuilder moduleBuilder) =>
+          CreateRequestHandler(moduleBuilder, "MissingConstraintsRequest", 3, 0, false);
+
+        protected static void CreateHandlerForExceedsMaximumClassesTest(ModuleBuilder moduleBuilder) =>
+            CreateRequestHandler(moduleBuilder, "ExceedsMaximumTypesClosingRequest", 1);
+
+        protected static void CreateHandlerForExceedsMaximumHandlerRegistrationsTest(ModuleBuilder moduleBuilder) =>
+            CreateRequestHandler(moduleBuilder, "ExceedsMaximumHandlerRegistrationsRequest", 4);
+
+        protected static void CreateHandlerForExceedsMaximumGenericTypeParametersTest(ModuleBuilder moduleBuilder) =>
+            CreateRequestHandler(moduleBuilder, "ExceedsMaximumGenericTypeParametersRequest", 11, 1);
+
+        protected static void CreateHandlerForTimeoutOccursTest(ModuleBuilder moduleBuilder) =>
+            CreateRequestHandler(moduleBuilder, "TimeoutOccursRequest", 3);
+
+        protected static void CreateHandlerForCombinationsTest(ModuleBuilder moduleBuilder, int numberOfGenericParameters) =>
+            CreateRequestHandler(moduleBuilder, "DynamicRequest", numberOfGenericParameters);
+
+        protected static void CreateClass(ModuleBuilder moduleBuilder, string className, Type interfaceType)
+        {
+            TypeBuilder typeBuilder = moduleBuilder.DefineType(className, TypeAttributes.Public);
+            typeBuilder.AddInterfaceImplementation(interfaceType);
+            typeBuilder.CreateTypeInfo();
+        }
+
+        protected static Type CreateInterface(ModuleBuilder moduleBuilder, string interfaceName)
+        {
+            TypeBuilder interfaceBuilder = moduleBuilder.DefineType(interfaceName, TypeAttributes.Public | TypeAttributes.Interface | TypeAttributes.Abstract);
+            return interfaceBuilder.CreateTypeInfo().AsType();
+        }
+
+        protected static AssemblyBuilder CreateAssemblyModuleBuilder(string name, int classes, int interfaces, Action<ModuleBuilder> handlerCreation)
+        {
+            AssemblyName assemblyName = new AssemblyName(name);
+            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("MainModule");
+
+            CreateTestClassesAndInterfaces(moduleBuilder, classes, interfaces);
+            handlerCreation.Invoke(moduleBuilder);
+
+            return assemblyBuilder;
+        }
+
+        protected static AssemblyBuilder GenerateCombinationsTestAssembly(int classes, int interfaces, int genericParameters)
+        {
+            AssemblyName assemblyName = new AssemblyName("DynamicAssembly");
+            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("MainModule");
+
+            CreateTestClassesAndInterfaces(moduleBuilder, classes, interfaces);
+            CreateHandlerForCombinationsTest(moduleBuilder, genericParameters);
+
+            return assemblyBuilder;
+        }
+
+        protected static string[] GetGenericParameterNames(int numberOfTypeParameters) => 
+            Enumerable.Range(1, numberOfTypeParameters).Select(i => $"T{i}").ToArray();
+
+        protected static void CreateRequestHandler(ModuleBuilder moduleBuilder, string requestName, int numberOfTypeParameters, int numberOfInterfaces = 0, bool includeConstraints = true)
+        {
+            if(numberOfInterfaces == 0)
+            {
+                numberOfInterfaces = numberOfTypeParameters;
+            }
+
+            // Define the dynamic request class
+            var handlerTypeBuilder = moduleBuilder!.DefineType($"{requestName}Handler", TypeAttributes.Public);
+            var requestTypeBuilder = moduleBuilder!.DefineType(requestName, TypeAttributes.Public);
+
+            // Define the generic parameters
+            string[] genericParameterNames = GetGenericParameterNames(numberOfTypeParameters);
+            var handlerGenericParameters = handlerTypeBuilder.DefineGenericParameters(genericParameterNames);
+            var requestGenericParameters = requestTypeBuilder.DefineGenericParameters(genericParameterNames);
+            requestTypeBuilder.AddInterfaceImplementation(typeof(IRequest));
+
+            if(includeConstraints) 
+            {
+                for (int i = 0; i < numberOfTypeParameters; i++)
+                {
+                    int interfaceIndex = i % numberOfInterfaces + 1;
+
+                    var constraintType = moduleBuilder.Assembly.GetType($"ITestInterface{interfaceIndex}");
+                    handlerGenericParameters[i].SetInterfaceConstraints(constraintType!);
+                    requestGenericParameters[i].SetInterfaceConstraints(constraintType!);
+                }
+            }
+
+            var requestType = requestTypeBuilder.CreateTypeInfo().AsType();
+            handlerTypeBuilder.AddInterfaceImplementation(typeof(IRequestHandler<>).MakeGenericType(requestType));
+
+            // Define the Handle method
+            MethodBuilder handleMethodBuilder = handlerTypeBuilder.DefineMethod(
+                "Handle",
+                MethodAttributes.Public | MethodAttributes.Virtual,
+                typeof(Task),
+                new[] { requestType, typeof(CancellationToken) });
+
+            ILGenerator ilGenerator = handleMethodBuilder.GetILGenerator();
+
+            ilGenerator.Emit(OpCodes.Ret);
+
+            // Implement the interface method
+            handlerTypeBuilder.DefineMethodOverride(handleMethodBuilder, typeof(IRequestHandler<>).MakeGenericType(requestType).GetMethod("Handle")!);
+
+            // Create the dynamic request class
+            handlerTypeBuilder.CreateTypeInfo();
+        }
+
+        protected static void CreateTestClassesAndInterfaces(ModuleBuilder moduleBuilder, int numberOfClasses, int numberOfInterfaces)
+        {
+
+            Type[] interfaces = new Type[numberOfInterfaces];
+            for (int i = 1; i <= numberOfInterfaces; i++)
+            {
+                string interfaceName = $"ITestInterface{i}";
+                interfaces[i - 1] = CreateInterface(moduleBuilder, interfaceName);
+            }
+
+            for (int i = 1; i <= numberOfClasses; i++)
+            {
+                string className = $"TestClass{i}";
+                Type interfaceType = interfaces[(i - 1) % numberOfInterfaces];
+                CreateClass(moduleBuilder, className, interfaceType);
+            }
+        }
+
+        protected List<Type[]> GenerateCombinations(Type[] types, int interfaces)
+        {
+            var groups = new List<Type>[interfaces];
+            for (int i = 0; i < interfaces; i++)
+            {
+                groups[i] = types.Where((t, index) => index % interfaces == i).ToList();
+            }
+
+            return GenerateCombinationsRecursive(groups, 0);
+        }
+
+        protected List<Type[]> GenerateCombinationsRecursive(List<Type>[] groups, int currentGroup)
+        {
+            var result = new List<Type[]>();
+
+            if (currentGroup == groups.Length)
+            {
+                result.Add(Array.Empty<Type>());
+                return result;
+            }
+
+            foreach (var type in groups[currentGroup])
+            {
+                foreach (var subCombination in GenerateCombinationsRecursive(groups, currentGroup + 1))
+                {
+                    result.Add(new[] { type }.Concat(subCombination).ToArray());
+                }
+            }
+
+            return result;
+        }
+
+        protected static int CalculateTotalCombinations(int numberOfClasses, int numberOfInterfaces, int numberOfTypeParameters)
+        {
+            var testClasses = Enumerable.Range(1, numberOfClasses)
+                .Select(i => $"TestClass{i}")
+                .ToArray();
+
+            var groups = new List<string>[numberOfInterfaces];
+            for (int i = 0; i < numberOfInterfaces; i++)
+            {
+                groups[i] = testClasses.Where((t, index) => index % numberOfInterfaces == i).ToList();
+            }
+
+            return groups
+                .Take(numberOfTypeParameters)
+                .Select(group => group.Count)
+                .Aggregate(1, (a, b) => a * b);
+        }
+    }
+}

--- a/test/MediatR.Tests/SendTests.cs
+++ b/test/MediatR.Tests/SendTests.cs
@@ -246,13 +246,14 @@ public class SendTests
         var services = new ServiceCollection();
         services.AddSingleton(dependency);       
         services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(Assembly.GetExecutingAssembly()));
-        services.AddTransient(typeof(IRequestHandler<VoidGenericPing<Pong>>), typeof(TestClass1PingRequestHandler));
+        services.AddTransient<IRequestHandler<VoidGenericPing<Pong>>,TestClass1PingRequestHandler>();
         var serviceProvider = services.BuildServiceProvider();
         var mediator = serviceProvider.GetService<IMediator>()!;
 
         var request = new VoidGenericPing<Pong>();
         await mediator.Send(request);
 
+        dependency.Called.ShouldBeFalse();
         dependency.CalledSpecific.ShouldBeTrue();
     }
 }


### PR DESCRIPTION
This PR adds support for handlers that contain multiple generic type parameters.  

This PR is a direct fix for issues #1047 and #1038 

Example:

```csharp

public interface IZong{}
public class Zong : IZong {}
public interface IDong{}
public class Dong : IDong {}
public interface IPong { string Message? { get; } }
public class Pong : IPong
{
    string Message? { get; set; }
}

//generic request definition
public class GenericPing<TPong, TZong, TDong> : IRequest<TPong>
    where TPong : IPong
    where TZong : IZong
    where TDong : IDong
{
    public T? ThePong { get; set; }
}

//generic request handler
public class GenericPingHandler<TPong, TZong, TDong> : IRequestHandler<GenericPing<TPong, TZong, TDong>, TPong>
    where TPong : IPong
    where TZong : IZong
    where TDong : IDong
{
    public Task<TPong> Handle(GenericPing<TPong, TZong, TDong> request, CancellationToken cancellationToken) => Task.FromResult(request.ThePong!);
}

//usage
var pong = _mediator.Send(new GenericPing<Pong, Zong, Dong>{ Pong = new() { Message = "Ping Pong" } });
Console.WriteLine(pong.Message); //would output "Ping Pong"

```
The issue that this PR solves was caused from only attempting to close the first type parameter in a generic request handler implementation.

This PR fixes that by finding the types that close for all type parameter and storing those in a list of lists.  Then all possible combinations of concrete implementations are generated from the lists and registered with the service provider.

Something that might need some discussion and thought will be what kinds of limitations we should put around this feature so that users are not misusing the library and creating a deadlock during service registration.

Along with this PR I added these configuration options with default values to the Configuraton object..

```csharp
 /// <summary>
    /// Configure the maximum number of type parameters that a generic request handler can have. To Disable this constraint, set the value to 0.
    /// </summary>
    public int MaxGenericTypeParameters { get; set; } = 10;

    /// <summary>
    /// Configure the maximum number of types that can close a generic request type parameter constraint.  To Disable this constraint, set the value to 0.
    /// </summary>
    public int MaxTypesClosing { get; set; } = 100;

    /// <summary>
    /// Configure the Maximum Amount of Generic RequestHandler Types MediatR will try to register.  To Disable this constraint, set the value to 0.
    /// </summary>
    public int MaxGenericTypeRegistrations { get; set; } = 125000;

    /// <summary>
    /// Configure the Timeout in Milliseconds that the GenericHandler Registration Process will exit with error.  To Disable this constraint, set the value to 0.
    /// </summary>
    public int RegistrationTimeout { get; set; } = 15000;
```
For now these are the default values, but I would like some feedback regarding these values.

- If the user tries to register types that have more than 10 generic type arguments, the library will throw exception.
- if the user tries to register a type that has no generic type constraints the library will throw exception.
- if the user trues to register a type that has too many types that can close a specific parameter, the library will throw exception.
- if the user tries to register a handler and somehow gets past the previous checks then the library will check the total combinations and throw exception if that number is greater than the max.
- and last if the registration takes more time to complete than the timeout value in milliseconds the library will throw exception.

I've also added some pretty extensive test methods that confirm this is working as expected.

@jbogard , @hisuwh Please review this at your convenience. 

Thanks,

 - Zach
 
 Edit: I apologize for not getting this done sooner.. I have just started a new job and haven't had the time. :)
 
 Edit: Added an opt out functionality. 
 ```csharp
   services.AddMediatR(cfg =>
   {
       //opt out flag set
       cfg.RegisterGenericHandlers = false;
       cfg.RegisterServicesFromAssembly(assembly);
   });
```
