### PR TITLE
Validate arguments of public methods#CA1062

### DIFF
--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -35,8 +35,8 @@ public class Mediator : IMediator
     /// <param name="publisher">Notification publisher. Defaults to <see cref="ForeachAwaitPublisher"/>.</param>
     public Mediator(IServiceProvider serviceProvider, INotificationPublisher publisher)
     {
-        _serviceProvider = serviceProvider;
-        _publisher = publisher;
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
     }
 
     public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)

--- a/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
+++ b/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using MediatR;
+﻿using MediatR;
 using MediatR.NotificationPublishers;
 using MediatR.Pipeline;
 using MediatR.Registration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -15,7 +15,7 @@ public class MediatRServiceConfiguration
     /// Optional filter for types to register. Default value is a function returning true.
     /// </summary>
     public Func<Type, bool> TypeEvaluator { get; set; } = t => true;
-    
+
     /// <summary>
     /// Mediator implementation type to register. Default is <see cref="Mediator"/>
     /// </summary>
@@ -108,7 +108,14 @@ public class MediatRServiceConfiguration
     /// <param name="type">Type from assembly to scan</param>
     /// <returns>This</returns>
     public MediatRServiceConfiguration RegisterServicesFromAssemblyContaining(Type type)
-        => RegisterServicesFromAssembly(type.Assembly);
+    {
+        if (type is null)
+        {
+            throw new ArgumentNullException(nameof(type));
+        }
+
+        return RegisterServicesFromAssembly(type.Assembly);
+    }
 
     /// <summary>
     /// Register various handlers from assembly
@@ -117,6 +124,11 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration RegisterServicesFromAssembly(Assembly assembly)
     {
+        if (assembly is null)
+        {
+            throw new ArgumentNullException(nameof(assembly));
+        }
+
         AssembliesToRegister.Add(assembly);
 
         return this;
@@ -130,6 +142,11 @@ public class MediatRServiceConfiguration
     public MediatRServiceConfiguration RegisterServicesFromAssemblies(
         params Assembly[] assemblies)
     {
+        if (assemblies is null)
+        {
+            throw new ArgumentNullException(nameof(assemblies));
+        }
+
         AssembliesToRegister.AddRange(assemblies);
 
         return this;
@@ -164,6 +181,11 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddBehavior(Type implementationType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
     {
+        if (implementationType is null)
+        {
+            throw new ArgumentNullException(nameof(implementationType));
+        }
+
         var implementedGenericInterfaces = implementationType.FindInterfacesThatClose(typeof(IPipelineBehavior<,>)).ToList();
 
         if (implementedGenericInterfaces.Count == 0)
@@ -188,6 +210,16 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddBehavior(Type serviceType, Type implementationType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
     {
+        if (serviceType is null)
+        {
+            throw new ArgumentNullException(nameof(serviceType));
+        }
+
+        if (implementationType is null)
+        {
+            throw new ArgumentNullException(nameof(implementationType));
+        }
+
         BehaviorsToRegister.Add(new ServiceDescriptor(serviceType, implementationType, serviceLifetime));
 
         return this;
@@ -201,6 +233,11 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddOpenBehavior(Type openBehaviorType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
     {
+        if (openBehaviorType is null)
+        {
+            throw new ArgumentNullException(nameof(openBehaviorType));
+        }
+
         if (!openBehaviorType.IsGenericType)
         {
             throw new InvalidOperationException($"{openBehaviorType.Name} must be generic");
@@ -231,7 +268,7 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddStreamBehavior<TServiceType, TImplementationType>(ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
         => AddStreamBehavior(typeof(TServiceType), typeof(TImplementationType), serviceLifetime);
-    
+
     /// <summary>
     /// Register a closed stream behavior type
     /// </summary>
@@ -241,11 +278,21 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddStreamBehavior(Type serviceType, Type implementationType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
     {
+        if (serviceType is null)
+        {
+            throw new ArgumentNullException(nameof(serviceType));
+        }
+
+        if (implementationType is null)
+        {
+            throw new ArgumentNullException(nameof(implementationType));
+        }
+
         StreamBehaviorsToRegister.Add(new ServiceDescriptor(serviceType, implementationType, serviceLifetime));
 
         return this;
     }
-    
+
     /// <summary>
     /// Register a closed stream behavior type against all <see cref="IStreamPipelineBehavior{TRequest,TResponse}"/> implementations
     /// </summary>
@@ -254,7 +301,7 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddStreamBehavior<TImplementationType>(ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
         => AddStreamBehavior(typeof(TImplementationType), serviceLifetime);
-    
+
     /// <summary>
     /// Register a closed stream behavior type against all <see cref="IStreamPipelineBehavior{TRequest,TResponse}"/> implementations
     /// </summary>
@@ -263,6 +310,11 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddStreamBehavior(Type implementationType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
     {
+        if (implementationType is null)
+        {
+            throw new ArgumentNullException(nameof(implementationType));
+        }
+
         var implementedGenericInterfaces = implementationType.FindInterfacesThatClose(typeof(IStreamPipelineBehavior<,>)).ToList();
 
         if (implementedGenericInterfaces.Count == 0)
@@ -277,7 +329,7 @@ public class MediatRServiceConfiguration
 
         return this;
     }
-    
+
     /// <summary>
     /// Registers an open stream behavior type against the <see cref="IStreamPipelineBehavior{TRequest,TResponse}"/> open generic interface type
     /// </summary>
@@ -286,6 +338,11 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddOpenStreamBehavior(Type openBehaviorType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
     {
+        if (openBehaviorType is null)
+        {
+            throw new ArgumentNullException(nameof(openBehaviorType));
+        }
+
         if (!openBehaviorType.IsGenericType)
         {
             throw new InvalidOperationException($"{openBehaviorType.Name} must be generic");
@@ -316,7 +373,7 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddRequestPreProcessor<TServiceType, TImplementationType>(ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
         => AddRequestPreProcessor(typeof(TServiceType), typeof(TImplementationType), serviceLifetime);
-    
+
     /// <summary>
     /// Register a closed request pre processor type
     /// </summary>
@@ -326,6 +383,16 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddRequestPreProcessor(Type serviceType, Type implementationType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
     {
+        if (serviceType is null)
+        {
+            throw new ArgumentNullException(nameof(serviceType));
+        }
+
+        if (implementationType is null)
+        {
+            throw new ArgumentNullException(nameof(implementationType));
+        }
+
         RequestPreProcessorsToRegister.Add(new ServiceDescriptor(serviceType, implementationType, serviceLifetime));
 
         return this;
@@ -349,6 +416,11 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddRequestPreProcessor(Type implementationType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
     {
+        if (implementationType is null)
+        {
+            throw new ArgumentNullException(nameof(implementationType));
+        }
+
         var implementedGenericInterfaces = implementationType.FindInterfacesThatClose(typeof(IRequestPreProcessor<>)).ToList();
 
         if (implementedGenericInterfaces.Count == 0)
@@ -360,10 +432,10 @@ public class MediatRServiceConfiguration
         {
             RequestPreProcessorsToRegister.Add(new ServiceDescriptor(implementedPreProcessorType, implementationType, serviceLifetime));
         }
-        
+
         return this;
     }
-    
+
     /// <summary>
     /// Registers an open request pre processor type against the <see cref="IRequestPreProcessor{TRequest}"/> open generic interface type
     /// </summary>
@@ -372,6 +444,11 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddOpenRequestPreProcessor(Type openBehaviorType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
     {
+        if (openBehaviorType is null)
+        {
+            throw new ArgumentNullException(nameof(openBehaviorType));
+        }
+
         if (!openBehaviorType.IsGenericType)
         {
             throw new InvalidOperationException($"{openBehaviorType.Name} must be generic");
@@ -392,7 +469,7 @@ public class MediatRServiceConfiguration
 
         return this;
     }
-    
+
     /// <summary>
     /// Register a closed request post processor type
     /// </summary>
@@ -402,7 +479,7 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddRequestPostProcessor<TServiceType, TImplementationType>(ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
         => AddRequestPostProcessor(typeof(TServiceType), typeof(TImplementationType), serviceLifetime);
-    
+
     /// <summary>
     /// Register a closed request post processor type
     /// </summary>
@@ -412,11 +489,21 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddRequestPostProcessor(Type serviceType, Type implementationType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
     {
+        if (serviceType is null)
+        {
+            throw new ArgumentNullException(nameof(serviceType));
+        }
+
+        if (implementationType is null)
+        {
+            throw new ArgumentNullException(nameof(implementationType));
+        }
+
         RequestPostProcessorsToRegister.Add(new ServiceDescriptor(serviceType, implementationType, serviceLifetime));
 
         return this;
     }
- 
+
     /// <summary>
     /// Register a closed request post processor type against all <see cref="IRequestPostProcessor{TRequest,TResponse}"/> implementations
     /// </summary>
@@ -425,7 +512,7 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddRequestPostProcessor<TImplementationType>(ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
         => AddRequestPostProcessor(typeof(TImplementationType), serviceLifetime);
-    
+
     /// <summary>
     /// Register a closed request post processor type against all <see cref="IRequestPostProcessor{TRequest,TResponse}"/> implementations
     /// </summary>
@@ -434,6 +521,11 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddRequestPostProcessor(Type implementationType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
     {
+        if (implementationType is null)
+        {
+            throw new ArgumentNullException(nameof(implementationType));
+        }
+
         var implementedGenericInterfaces = implementationType.FindInterfacesThatClose(typeof(IRequestPostProcessor<,>)).ToList();
 
         if (implementedGenericInterfaces.Count == 0)
@@ -447,7 +539,7 @@ public class MediatRServiceConfiguration
         }
         return this;
     }
-    
+
     /// <summary>
     /// Registers an open request post processor type against the <see cref="IRequestPostProcessor{TRequest,TResponse}"/> open generic interface type
     /// </summary>
@@ -456,6 +548,11 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddOpenRequestPostProcessor(Type openBehaviorType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
     {
+        if (openBehaviorType is null)
+        {
+            throw new ArgumentNullException(nameof(openBehaviorType));
+        }
+
         if (!openBehaviorType.IsGenericType)
         {
             throw new InvalidOperationException($"{openBehaviorType.Name} must be generic");

--- a/src/MediatR/MicrosoftExtensionsDI/ServiceCollectionExtensions.cs
+++ b/src/MediatR/MicrosoftExtensionsDI/ServiceCollectionExtensions.cs
@@ -26,6 +26,16 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddMediatR(this IServiceCollection services, 
         Action<MediatRServiceConfiguration> configuration)
     {
+        if (services is null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
+        if (configuration is null)
+        {
+            throw new ArgumentNullException(nameof(configuration));
+        }
+
         var serviceConfig = new MediatRServiceConfiguration();
 
         configuration.Invoke(serviceConfig);
@@ -42,6 +52,16 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddMediatR(this IServiceCollection services, 
         MediatRServiceConfiguration configuration)
     {
+        if (services is null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
+        if (configuration is null)
+        {
+            throw new ArgumentNullException(nameof(configuration));
+        }
+
         if (!configuration.AssembliesToRegister.Any())
         {
             throw new ArgumentException("No assemblies found to scan. Supply at least one assembly to scan for handlers.");

--- a/src/MediatR/NotificationPublishers/ForeachAwaitPublisher.cs
+++ b/src/MediatR/NotificationPublishers/ForeachAwaitPublisher.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -16,6 +17,16 @@ public class ForeachAwaitPublisher : INotificationPublisher
 {
     public async Task Publish(IEnumerable<NotificationHandlerExecutor> handlerExecutors, INotification notification, CancellationToken cancellationToken)
     {
+        if (handlerExecutors is null)
+        {
+            throw new ArgumentNullException(nameof(handlerExecutors));
+        }
+
+        if (notification is null)
+        {
+            throw new ArgumentNullException(nameof(notification));
+        }
+
         foreach (var handler in handlerExecutors)
         {
             await handler.HandlerCallback(notification, cancellationToken).ConfigureAwait(false);

--- a/src/MediatR/NotificationPublishers/TaskWhenAllPublisher.cs
+++ b/src/MediatR/NotificationPublishers/TaskWhenAllPublisher.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,6 +20,16 @@ public class TaskWhenAllPublisher : INotificationPublisher
 {
     public Task Publish(IEnumerable<NotificationHandlerExecutor> handlerExecutors, INotification notification, CancellationToken cancellationToken)
     {
+        if (handlerExecutors is null)
+        {
+            throw new ArgumentNullException(nameof(handlerExecutors));
+        }
+
+        if (notification is null)
+        {
+            throw new ArgumentNullException(nameof(notification));
+        }
+
         var tasks = handlerExecutors
             .Select(handler => handler.HandlerCallback(notification, cancellationToken))
             .ToArray();

--- a/src/MediatR/Pipeline/IRequestExceptionAction.cs
+++ b/src/MediatR/Pipeline/IRequestExceptionAction.cs
@@ -3,7 +3,7 @@ namespace MediatR.Pipeline;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-    
+
 /// <summary>
 /// Defines an exception action for a request
 /// </summary>

--- a/src/MediatR/Pipeline/RequestExceptionHandlerState.cs
+++ b/src/MediatR/Pipeline/RequestExceptionHandlerState.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace MediatR.Pipeline;
 
 /// <summary>
@@ -22,6 +24,11 @@ public class RequestExceptionHandlerState<TResponse>
     /// <param name="response">Set the response that will be returned.</param>
     public void SetHandled(TResponse response)
     {
+        if (response is null)
+        {
+            throw new ArgumentNullException(nameof(response));
+        }
+
         Handled = true;
         Response = response;
     }

--- a/src/MediatR/Pipeline/RequestExceptionProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestExceptionProcessorBehavior.cs
@@ -21,10 +21,21 @@ public class RequestExceptionProcessorBehavior<TRequest, TResponse> : IPipelineB
 {
     private readonly IServiceProvider _serviceProvider;
 
-    public RequestExceptionProcessorBehavior(IServiceProvider serviceProvider) => _serviceProvider = serviceProvider;
+    public RequestExceptionProcessorBehavior(IServiceProvider serviceProvider)
+        => _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
 
     public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        if (next is null)
+        {
+            throw new ArgumentNullException(nameof(next));
+        }
+
         try
         {
             return await next().ConfigureAwait(false);

--- a/src/MediatR/Pipeline/RequestPostProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestPostProcessorBehavior.cs
@@ -1,5 +1,6 @@
 namespace MediatR.Pipeline;
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,11 +15,21 @@ public class RequestPostProcessorBehavior<TRequest, TResponse> : IPipelineBehavi
 {
     private readonly IEnumerable<IRequestPostProcessor<TRequest, TResponse>> _postProcessors;
 
-    public RequestPostProcessorBehavior(IEnumerable<IRequestPostProcessor<TRequest, TResponse>> postProcessors) 
-        => _postProcessors = postProcessors;
+    public RequestPostProcessorBehavior(IEnumerable<IRequestPostProcessor<TRequest, TResponse>> postProcessors)
+        => _postProcessors = postProcessors ?? throw new ArgumentNullException(nameof(postProcessors));
 
     public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        if (next is null)
+        {
+            throw new ArgumentNullException(nameof(next));
+        }
+
         var response = await next().ConfigureAwait(false);
 
         foreach (var processor in _postProcessors)

--- a/src/MediatR/Pipeline/RequestPreProcessorBehavior.cs
+++ b/src/MediatR/Pipeline/RequestPreProcessorBehavior.cs
@@ -1,5 +1,6 @@
 namespace MediatR.Pipeline;
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,10 +16,20 @@ public class RequestPreProcessorBehavior<TRequest, TResponse> : IPipelineBehavio
     private readonly IEnumerable<IRequestPreProcessor<TRequest>> _preProcessors;
 
     public RequestPreProcessorBehavior(IEnumerable<IRequestPreProcessor<TRequest>> preProcessors) 
-        => _preProcessors = preProcessors;
+        => _preProcessors = preProcessors ?? throw new ArgumentNullException(nameof(preProcessors));
 
     public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        if (next is null)
+        {
+            throw new ArgumentNullException(nameof(next));
+        }
+
         foreach (var processor in _preProcessors)
         {
             await processor.Process(request, cancellationToken).ConfigureAwait(false);

--- a/src/MediatR/Registration/ServiceRegistrar.cs
+++ b/src/MediatR/Registration/ServiceRegistrar.cs
@@ -18,6 +18,11 @@ public static class ServiceRegistrar
 
     public static void SetGenericRequestHandlerRegistrationLimitations(MediatRServiceConfiguration configuration)
     {
+        if (configuration is null)
+        {
+            throw new ArgumentNullException(nameof(configuration));
+        }
+
         MaxGenericTypeParameters = configuration.MaxGenericTypeParameters;
         MaxTypesClosing = configuration.MaxTypesClosing;
         MaxGenericTypeRegistrations = configuration.MaxGenericTypeRegistrations;
@@ -26,7 +31,17 @@ public static class ServiceRegistrar
 
     public static void AddMediatRClassesWithTimeout(IServiceCollection services, MediatRServiceConfiguration configuration)
     {
-        using(var cts = new CancellationTokenSource(RegistrationTimeout))
+        if (services is null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
+        if (configuration is null)
+        {
+            throw new ArgumentNullException(nameof(configuration));
+        }
+
+        using (var cts = new CancellationTokenSource(RegistrationTimeout))
         {
             try
             {
@@ -40,7 +55,16 @@ public static class ServiceRegistrar
     }
 
     public static void AddMediatRClasses(IServiceCollection services, MediatRServiceConfiguration configuration, CancellationToken cancellationToken = default)
-    {   
+    {
+        if (services is null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
+        if (configuration is null)
+        {
+            throw new ArgumentNullException(nameof(configuration));
+        }
 
         var assembliesToScan = configuration.AssembliesToRegister.Distinct().ToArray();
 
@@ -254,6 +278,16 @@ public static class ServiceRegistrar
     // Method to generate combinations recursively
     public static List<List<Type>> GenerateCombinations(Type requestType, List<List<Type>> lists, int depth = 0, CancellationToken cancellationToken = default)
     {
+        if (requestType is null)
+        {
+            throw new ArgumentNullException(nameof(requestType));
+        }
+
+        if (lists is null)
+        {
+            throw new ArgumentNullException(nameof(lists));
+        }
+
         if (depth == 0)
         {
             // Initial checks
@@ -389,6 +423,16 @@ public static class ServiceRegistrar
 
     public static void AddRequiredServices(IServiceCollection services, MediatRServiceConfiguration serviceConfiguration)
     {
+        if (services is null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
+        if (serviceConfiguration is null)
+        {
+            throw new ArgumentNullException(nameof(serviceConfiguration));
+        }
+
         // Use TryAdd, so any existing ServiceFactory/IMediator registration doesn't get overridden
         services.TryAdd(new ServiceDescriptor(typeof(IMediator), serviceConfiguration.MediatorImplementationType, serviceConfiguration.Lifetime));
         services.TryAdd(new ServiceDescriptor(typeof(ISender), sp => sp.GetRequiredService<IMediator>(), serviceConfiguration.Lifetime));

--- a/src/MediatR/Wrappers/NotificationHandlerWrapper.cs
+++ b/src/MediatR/Wrappers/NotificationHandlerWrapper.cs
@@ -21,6 +21,21 @@ public class NotificationHandlerWrapperImpl<TNotification> : NotificationHandler
         Func<IEnumerable<NotificationHandlerExecutor>, INotification, CancellationToken, Task> publish,
         CancellationToken cancellationToken)
     {
+        if (notification is null)
+        {
+            throw new ArgumentNullException(nameof(notification));
+        }
+
+        if (serviceFactory is null)
+        {
+            throw new ArgumentNullException(nameof(serviceFactory));
+        }
+
+        if (publish is null)
+        {
+            throw new ArgumentNullException(nameof(publish));
+        }
+
         var handlers = serviceFactory
             .GetServices<INotificationHandler<TNotification>>()
             .Select(static x => new NotificationHandlerExecutor(x, (theNotification, theToken) => x.Handle((TNotification)theNotification, theToken)));

--- a/src/MediatR/Wrappers/RequestHandlerWrapper.cs
+++ b/src/MediatR/Wrappers/RequestHandlerWrapper.cs
@@ -34,6 +34,16 @@ public class RequestHandlerWrapperImpl<TRequest, TResponse> : RequestHandlerWrap
     public override Task<TResponse> Handle(IRequest<TResponse> request, IServiceProvider serviceProvider,
         CancellationToken cancellationToken)
     {
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        if (serviceProvider is null)
+        {
+            throw new ArgumentNullException(nameof(serviceProvider));
+        }
+
         Task<TResponse> Handler() => serviceProvider.GetRequiredService<IRequestHandler<TRequest, TResponse>>()
             .Handle((TRequest) request, cancellationToken);
 
@@ -55,6 +65,16 @@ public class RequestHandlerWrapperImpl<TRequest> : RequestHandlerWrapper
     public override Task<Unit> Handle(IRequest request, IServiceProvider serviceProvider,
         CancellationToken cancellationToken)
     {
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        if (serviceProvider is null)
+        {
+            throw new ArgumentNullException(nameof(serviceProvider));
+        }
+
         async Task<Unit> Handler()
         {
             await serviceProvider.GetRequiredService<IRequestHandler<TRequest>>()

--- a/test/MediatR.Tests/ArgumentNullExceptionTests/MediatorTests.cs
+++ b/test/MediatR.Tests/ArgumentNullExceptionTests/MediatorTests.cs
@@ -1,0 +1,150 @@
+﻿using Lamar;
+using MediatR.NotificationPublishers;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MediatR.Tests.ArgumentNullExceptionTests;
+
+public class MediatorTests
+{
+    private class Ping : IRequest<Pong> { }
+
+    private class Pong { }
+
+    private class NullPing : IRequest<Pong> { }
+
+    private class VoidNullPing : IRequest { }
+
+    private class NullPinged : INotification { }
+
+    [Fact]
+    public void Should_throw_for_ctor_mediator_when_service_provider_is_null()
+    {
+        IServiceProvider serviceProvider = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => new Mediator(serviceProvider));
+
+        Assert.Equal(nameof(serviceProvider), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_overload_ctor_mediator_with_notification_when_service_provider_is_null()
+    {
+        IServiceProvider serviceProvider = null!;
+        INotificationPublisher publisher = new ForeachAwaitPublisher();
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => new Mediator(serviceProvider, publisher));
+
+        Assert.Equal(nameof(serviceProvider), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_overload_ctor_mediator_with_notification_when_publisher_is_null()
+    {
+        var serviceCollection = new ServiceCollection();
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        INotificationPublisher publisher = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => new Mediator(serviceProvider, publisher));
+
+        Assert.Equal(nameof(publisher), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_send_when_request_is_null()
+    {
+        var container = new Container(cfg =>
+        {
+            cfg.Scan(scanner =>
+            {
+                scanner.AssemblyContainingType(typeof(NullPing));
+                scanner.IncludeNamespaceContainingType<Ping>();
+                scanner.WithDefaultConventions();
+                scanner.AddAllTypesOf(typeof(IRequestHandler<,>));
+            });
+            cfg.For<IMediator>().Use<Mediator>();
+        });
+        var mediator = container.GetInstance<IMediator>();
+
+        NullPing request = null!;
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await mediator.Send(request));
+        Assert.Equal(nameof(request), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_void_send_when_request_is_null()
+    {
+        var container = new Container(cfg =>
+        {
+            cfg.Scan(scanner =>
+            {
+                scanner.AssemblyContainingType(typeof(VoidNullPing));
+                scanner.IncludeNamespaceContainingType<Ping>();
+                scanner.WithDefaultConventions();
+                scanner.AddAllTypesOf(typeof(IRequestHandler<,>));
+            });
+            cfg.For<IMediator>().Use<Mediator>();
+        });
+        var mediator = container.GetInstance<IMediator>();
+
+        VoidNullPing request = null!;
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await mediator.Send(request));
+        Assert.Equal(nameof(request), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_publish_when_request_is_null()
+    {
+        var container = new Container(cfg =>
+        {
+            cfg.Scan(scanner =>
+            {
+                scanner.AssemblyContainingType(typeof(NullPinged));
+                scanner.IncludeNamespaceContainingType<Ping>();
+                scanner.WithDefaultConventions();
+                scanner.AddAllTypesOf(typeof(IRequestHandler<,>));
+            });
+            cfg.For<IMediator>().Use<Mediator>();
+        });
+        var mediator = container.GetInstance<IMediator>();
+
+        NullPinged notification = null!;
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await mediator.Publish(notification));
+        Assert.Equal(nameof(notification), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_publish_when_request_is_null_object()
+    {
+        var container = new Container(cfg =>
+        {
+            cfg.Scan(scanner =>
+            {
+                scanner.AssemblyContainingType(typeof(NullPinged));
+                scanner.IncludeNamespaceContainingType<Ping>();
+                scanner.WithDefaultConventions();
+                scanner.AddAllTypesOf(typeof(IRequestHandler<,>));
+            });
+            cfg.For<IMediator>().Use<Mediator>();
+        });
+        var mediator = container.GetInstance<IMediator>();
+
+        object notification = null!;
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await mediator.Publish(notification));
+        Assert.Equal(nameof(notification), exception.ParamName);
+    }
+}

--- a/test/MediatR.Tests/ArgumentNullExceptionTests/MicrosoftExtensionsDI/MediatRServiceConfigurationTests.cs
+++ b/test/MediatR.Tests/ArgumentNullExceptionTests/MicrosoftExtensionsDI/MediatRServiceConfigurationTests.cs
@@ -1,0 +1,229 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace MediatR.Tests.ArgumentNullExceptionTests.MicrosoftExtensionsDI;
+
+public class MediatRServiceConfigurationTests
+{
+    private readonly MediatRServiceConfiguration _configuration = new();
+
+    [Fact]
+    public void Should_throw_for_register_services_from_assembly_containing_when_type_is_null()
+    {
+        Type type = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => _configuration.RegisterServicesFromAssemblyContaining(type));
+
+        Assert.Equal(nameof(type), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_register_services_from_assembly_when_assembly_is_null()
+    {
+        Assembly assembly = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => _configuration.RegisterServicesFromAssembly(assembly));
+
+        Assert.Equal(nameof(assembly), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_register_services_from_assemblies_when_assemblies_is_null()
+    {
+        Assembly[] assemblies = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => _configuration.RegisterServicesFromAssemblies(assemblies));
+
+        Assert.Equal(nameof(assemblies), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_behavior_when_type_is_null()
+    {
+        Type implementationType = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => _configuration.AddBehavior(implementationType, default(ServiceLifetime)));
+
+        Assert.Equal(nameof(implementationType), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_behavior_with_two_type_when_service_type_is_null()
+    {
+        Type serviceType = null!;
+        var implementationType = typeof(string);
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => _configuration.AddBehavior(serviceType, implementationType, default(ServiceLifetime)));
+
+        Assert.Equal(nameof(serviceType), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_behavior_with_two_type_when_implementation_type_is_null()
+    {
+        var serviceType = typeof(string);
+        Type implementationType = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => _configuration.AddBehavior(serviceType, implementationType, default(ServiceLifetime)));
+
+        Assert.Equal(nameof(implementationType), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_open_behavior_when_open_behavior_type_is_null()
+    {
+        Type openBehaviorType = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => _configuration.AddOpenBehavior(openBehaviorType, default(ServiceLifetime)));
+
+        Assert.Equal(nameof(openBehaviorType), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_stream_behavior_with_one_type_when_implementation_type_is_null()
+    {
+        Type implementationType = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => _configuration.AddStreamBehavior(implementationType, default(ServiceLifetime)));
+
+        Assert.Equal(nameof(implementationType), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_stream_behavior_with_two_type_when_service_type_is_null()
+    {
+        Type serviceType = null!;
+        var implementationType = typeof(string);
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => _configuration.AddStreamBehavior(serviceType, implementationType, default(ServiceLifetime)));
+
+        Assert.Equal(nameof(serviceType), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_stream_behavior_with_two_type_when_implementation_type_is_null()
+    {
+        var serviceType = typeof(string);
+        Type implementationType = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => _configuration.AddStreamBehavior(serviceType, implementationType, default(ServiceLifetime)));
+
+        Assert.Equal(nameof(implementationType), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_open_stream_behavior_with_two_type_when_open_behavior_type_is_null()
+    {
+        Type openBehaviorType = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => _configuration.AddOpenStreamBehavior(openBehaviorType, default(ServiceLifetime)));
+
+        Assert.Equal(nameof(openBehaviorType), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_request_pre_processor_with_one_type_when_implementation_type_is_null()
+    {
+        Type implementationType = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => _configuration.AddRequestPreProcessor(implementationType, default(ServiceLifetime)));
+
+        Assert.Equal(nameof(implementationType), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_request_pre_processor_with_two_type_when_service_type_is_null()
+    {
+        Type serviceType = null!;
+        var implementationType = typeof(string);
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => _configuration.AddRequestPreProcessor(serviceType, implementationType, default(ServiceLifetime)));
+
+        Assert.Equal(nameof(serviceType), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_request_pre_processor_with_two_type_when_implementation_type_is_null()
+    {
+        var serviceType = typeof(string);
+        Type implementationType = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => _configuration.AddRequestPreProcessor(serviceType, implementationType, default(ServiceLifetime)));
+
+        Assert.Equal(nameof(implementationType), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_open_request_pre_processor_when_open_behavior_type_is_null()
+    {
+        Type openBehaviorType = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => _configuration.AddOpenRequestPreProcessor(openBehaviorType, default(ServiceLifetime)));
+
+        Assert.Equal(nameof(openBehaviorType), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_request_post_processor_with_one_type_when_implementation_type_is_null()
+    {
+        Type implementationType = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => _configuration.AddRequestPostProcessor(implementationType, default(ServiceLifetime)));
+
+        Assert.Equal(nameof(implementationType), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_request_post_processor_with_two_type_when_service_type_is_null()
+    {
+        Type serviceType = null!;
+        var implementationType = typeof(string);
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => _configuration.AddRequestPostProcessor(serviceType, implementationType, default(ServiceLifetime)));
+
+        Assert.Equal(nameof(serviceType), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_request_post_processor_with_two_type_when_implementation_type_is_null()
+    {
+        var serviceType = typeof(string);
+        Type implementationType = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => _configuration.AddRequestPostProcessor(serviceType, implementationType, default(ServiceLifetime)));
+
+        Assert.Equal(nameof(implementationType), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_open_request_post_processor_when_open_behavior_type_is_null()
+    {
+        Type openBehaviorType = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => _configuration.AddOpenRequestPostProcessor(openBehaviorType, default(ServiceLifetime)));
+
+        Assert.Equal(nameof(openBehaviorType), exception.ParamName);
+    }
+}

--- a/test/MediatR.Tests/ArgumentNullExceptionTests/MicrosoftExtensionsDI/ServiceCollectionExtensionsTests.cs
+++ b/test/MediatR.Tests/ArgumentNullExceptionTests/MicrosoftExtensionsDI/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using System;
+using Xunit;
+
+namespace MediatR.Tests.ArgumentNullExceptionTests.MicrosoftExtensionsDI;
+
+public class ServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void Should_throw_for_add_mediatr_with_action_when_services_is_null()
+    {
+        IServiceCollection services = null!;
+        Action<MediatRServiceConfiguration> configuration = (_) => { };
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => services.AddMediatR(configuration));
+
+        Assert.Equal(nameof(services), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_mediatr_with_action_when_configuration_is_null()
+    {
+        var services = new ServiceCollection();
+        Action<MediatRServiceConfiguration> configuration = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => services.AddMediatR(configuration));
+
+        Assert.Equal(nameof(configuration), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_mediatr_when_services_is_null()
+    {
+        IServiceCollection services = null!;
+        var configuration = new MediatRServiceConfiguration();
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => services.AddMediatR(configuration));
+
+        Assert.Equal(nameof(services), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_mediatr_when_configuration_is_null()
+    {
+        var services = new ServiceCollection();
+        MediatRServiceConfiguration configuration = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => services.AddMediatR(configuration));
+
+        Assert.Equal(nameof(configuration), exception.ParamName);
+    }
+}

--- a/test/MediatR.Tests/ArgumentNullExceptionTests/NotificationPublishers/ForeachAwaitPublisherTests.cs
+++ b/test/MediatR.Tests/ArgumentNullExceptionTests/NotificationPublishers/ForeachAwaitPublisherTests.cs
@@ -1,0 +1,40 @@
+﻿using MediatR.NotificationPublishers;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MediatR.Tests.ArgumentNullExceptionTests.NotificationPublishers;
+
+public class ForeachAwaitPublisherTests
+{
+    private sealed record Command : INotification;
+
+    private readonly ForeachAwaitPublisher _foreachAwaitPublisher = new();
+
+    [Fact]
+    public async Task Should_throw_for_publish_when_handler_executors_is_null()
+    {
+        IEnumerable<NotificationHandlerExecutor> handlerExecutors = null!;
+        INotification notification = new Command();
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await _foreachAwaitPublisher.Publish(handlerExecutors, notification, default(CancellationToken)));
+
+        Assert.Equal(nameof(handlerExecutors), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_publish_when_notification_is_null()
+    {
+        IEnumerable<NotificationHandlerExecutor> handlerExecutors = new List<NotificationHandlerExecutor>();
+        INotification notification = null!;
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await _foreachAwaitPublisher.Publish(handlerExecutors, notification, default(CancellationToken)));
+
+        Assert.Equal(nameof(notification), exception.ParamName);
+    }
+}

--- a/test/MediatR.Tests/ArgumentNullExceptionTests/NotificationPublishers/TaskWhenAllPublisherTests.cs
+++ b/test/MediatR.Tests/ArgumentNullExceptionTests/NotificationPublishers/TaskWhenAllPublisherTests.cs
@@ -1,0 +1,40 @@
+﻿using MediatR.NotificationPublishers;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MediatR.Tests.ArgumentNullExceptionTests.NotificationPublishers;
+
+public class TaskWhenAllPublisherTests
+{
+    private sealed record Command : INotification;
+
+    private readonly TaskWhenAllPublisher _taskWhenAllPublisher = new();
+
+    [Fact]
+    public async Task Should_throw_for_publish_when_handler_executors_is_null()
+    {
+        IEnumerable<NotificationHandlerExecutor> handlerExecutors = null!;
+        INotification notification = new Command();
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await _taskWhenAllPublisher.Publish(handlerExecutors, notification, default(CancellationToken)));
+
+        Assert.Equal(nameof(handlerExecutors), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_publish_when_notification_is_null()
+    {
+        IEnumerable<NotificationHandlerExecutor> handlerExecutors = new List<NotificationHandlerExecutor>();
+        INotification notification = null!;
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await _taskWhenAllPublisher.Publish(handlerExecutors, notification, default(CancellationToken)));
+
+        Assert.Equal(nameof(notification), exception.ParamName);
+    }
+}

--- a/test/MediatR.Tests/ArgumentNullExceptionTests/Pipeline/RequestExceptionActionProcessorBehaviorTests.cs
+++ b/test/MediatR.Tests/ArgumentNullExceptionTests/Pipeline/RequestExceptionActionProcessorBehaviorTests.cs
@@ -1,0 +1,55 @@
+﻿using MediatR.Pipeline;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MediatR.Tests.ArgumentNullExceptionTests.Pipeline;
+
+public class RequestExceptionActionProcessorBehaviorTests
+{
+    private sealed record Command : IRequest<string>;
+
+    [Fact]
+    public void Should_throw_for_ctor_when_service_provider_is_null()
+    {
+        IServiceProvider serviceProvider = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => new RequestExceptionActionProcessorBehavior<Command, string>(serviceProvider));
+
+        Assert.Equal(nameof(serviceProvider), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_handle_when_request_is_null()
+    {
+        var serviceCollection = new ServiceCollection();
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var requestExceptionActionProcessorBehavior = new RequestExceptionActionProcessorBehavior<Command, string>(serviceProvider);
+        Command request = null!;
+        RequestHandlerDelegate<string> next = () => new Task<string>(() => string.Empty);
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await requestExceptionActionProcessorBehavior.Handle(request, next, CancellationToken.None));
+
+        Assert.Equal(nameof(request), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_handle_when_next_is_null()
+    {
+        var serviceCollection = new ServiceCollection();
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var requestExceptionActionProcessorBehavior = new RequestExceptionActionProcessorBehavior<Command, string>(serviceProvider);
+        var request = new Command();
+        RequestHandlerDelegate<string> next = null!;
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await requestExceptionActionProcessorBehavior.Handle(request, next, CancellationToken.None));
+
+        Assert.Equal(nameof(next), exception.ParamName);
+    }
+}

--- a/test/MediatR.Tests/ArgumentNullExceptionTests/Pipeline/RequestExceptionHandlerStateTests.cs
+++ b/test/MediatR.Tests/ArgumentNullExceptionTests/Pipeline/RequestExceptionHandlerStateTests.cs
@@ -1,0 +1,21 @@
+﻿using MediatR.Pipeline;
+using Shouldly;
+using System;
+using Xunit;
+
+namespace MediatR.Tests.ArgumentNullExceptionTests.Pipeline;
+
+public class RequestExceptionHandlerStateTests
+{
+    [Fact]
+    public void Should_throw_for_ctor_when_service_provider_is_null()
+    {
+        var requestExceptionHandlerState = new RequestExceptionHandlerState<string>();
+        string response = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => requestExceptionHandlerState.SetHandled(response));
+
+        Assert.Equal(nameof(response), exception.ParamName);
+    }
+}

--- a/test/MediatR.Tests/ArgumentNullExceptionTests/Pipeline/RequestExceptionProcessorBehaviorTests.cs
+++ b/test/MediatR.Tests/ArgumentNullExceptionTests/Pipeline/RequestExceptionProcessorBehaviorTests.cs
@@ -1,0 +1,55 @@
+﻿using MediatR.Pipeline;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MediatR.Tests.ArgumentNullExceptionTests.Pipeline;
+
+public class RequestExceptionProcessorBehaviorTests
+{
+    private sealed record Command : IRequest<string>;
+
+    [Fact]
+    public void Should_throw_for_ctor_when_service_provider_is_null()
+    {
+        IServiceProvider serviceProvider = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => new RequestExceptionProcessorBehavior<Command, string>(serviceProvider));
+
+        Assert.Equal(nameof(serviceProvider), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_handle_when_request_is_null()
+    {
+        var serviceCollection = new ServiceCollection();
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var requestExceptionProcessorBehavior = new RequestExceptionProcessorBehavior<Command, string>(serviceProvider);
+        Command request = null!;
+        RequestHandlerDelegate<string> next = () => new Task<string>(() => string.Empty);
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await requestExceptionProcessorBehavior.Handle(request, next, CancellationToken.None));
+
+        Assert.Equal(nameof(request), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_handle_when_next_is_null()
+    {
+        var serviceCollection = new ServiceCollection();
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var requestExceptionProcessorBehavior = new RequestExceptionProcessorBehavior<Command, string>(serviceProvider);
+        var request = new Command();
+        RequestHandlerDelegate<string> next = null!;
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await requestExceptionProcessorBehavior.Handle(request, next, CancellationToken.None));
+
+        Assert.Equal(nameof(next), exception.ParamName);
+    }
+}

--- a/test/MediatR.Tests/ArgumentNullExceptionTests/Pipeline/RequestPostProcessorBehaviorTests.cs
+++ b/test/MediatR.Tests/ArgumentNullExceptionTests/Pipeline/RequestPostProcessorBehaviorTests.cs
@@ -1,0 +1,53 @@
+﻿using MediatR.Pipeline;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MediatR.Tests.ArgumentNullExceptionTests.Pipeline;
+
+public class RequestPostProcessorBehaviorTests
+{
+    private sealed record Command : IRequest<string>;
+
+    [Fact]
+    public void Should_throw_for_ctor_when_service_provider_is_null()
+    {
+        IEnumerable<IRequestPostProcessor<Command, string>> postProcessors = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => new RequestPostProcessorBehavior<Command, string>(postProcessors));
+
+        Assert.Equal(nameof(postProcessors), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_handle_when_request_is_null()
+    {
+        var postProcessors = new List<IRequestPostProcessor<Command, string>>();
+        var requestPostProcessorBehavior = new RequestPostProcessorBehavior<Command, string>(postProcessors);
+        Command request = null!;
+        RequestHandlerDelegate<string> next = () => new Task<string>(() => string.Empty);
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await requestPostProcessorBehavior.Handle(request, next, CancellationToken.None));
+
+        Assert.Equal(nameof(request), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_handle_when_next_is_null()
+    {
+        var postProcessors = new List<IRequestPostProcessor<Command, string>>();
+        var requestPostProcessorBehavior = new RequestPostProcessorBehavior<Command, string>(postProcessors);
+        var request = new Command();
+        RequestHandlerDelegate<string> next = null!;
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await requestPostProcessorBehavior.Handle(request, next, CancellationToken.None));
+
+        Assert.Equal(nameof(next), exception.ParamName);
+    }
+}

--- a/test/MediatR.Tests/ArgumentNullExceptionTests/Pipeline/RequestPreProcessorBehaviorTests.cs
+++ b/test/MediatR.Tests/ArgumentNullExceptionTests/Pipeline/RequestPreProcessorBehaviorTests.cs
@@ -1,0 +1,53 @@
+﻿using MediatR.Pipeline;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MediatR.Tests.ArgumentNullExceptionTests.Pipeline;
+
+public class RequestPreProcessorBehaviorTests
+{
+    private sealed record Command : IRequest<string>;
+
+    [Fact]
+    public void Should_throw_for_ctor_when_configuration_is_null()
+    {
+        IEnumerable<IRequestPreProcessor<Command>> preProcessors = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => new RequestPreProcessorBehavior<Command, string>(preProcessors));
+
+        Assert.Equal(nameof(preProcessors), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_handle_when_request_is_null()
+    {
+        IEnumerable<IRequestPreProcessor<Command>> preProcessors = new List<IRequestPreProcessor<Command>>();
+        var requestPreProcessorBehavior = new RequestPreProcessorBehavior<Command, string>(preProcessors);
+        Command request = null!;
+        RequestHandlerDelegate<string> next = () => new Task<string>(() => string.Empty);
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await requestPreProcessorBehavior.Handle(request, next, CancellationToken.None));
+
+        Assert.Equal(nameof(request), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_handle_when_next_is_null()
+    {
+        IEnumerable<IRequestPreProcessor<Command>> preProcessors = new List<IRequestPreProcessor<Command>>();
+        var requestPreProcessorBehavior = new RequestPreProcessorBehavior<Command, string>(preProcessors);
+        var request = new Command();
+        RequestHandlerDelegate<string> next = null!;
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await requestPreProcessorBehavior.Handle(request, next, CancellationToken.None));
+
+        Assert.Equal(nameof(next), exception.ParamName);
+    }
+}

--- a/test/MediatR.Tests/ArgumentNullExceptionTests/Registration/ServiceRegistrarTests.cs
+++ b/test/MediatR.Tests/ArgumentNullExceptionTests/Registration/ServiceRegistrarTests.cs
@@ -1,0 +1,119 @@
+﻿using MediatR.Registration;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Xunit;
+
+namespace MediatR.Tests.ArgumentNullExceptionTests.Registration;
+
+public class ServiceRegistrarTests
+{
+    [Fact]
+    public void Should_throw_for_set_generic_request_handler_registration_limitations_when_configuration_is_null()
+    {
+        MediatRServiceConfiguration configuration = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => ServiceRegistrar.SetGenericRequestHandlerRegistrationLimitations(configuration));
+
+        Assert.Equal(nameof(configuration), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_mediatr_classes_with_timeout_when_services_is_null()
+    {
+        var configuration = new MediatRServiceConfiguration();
+        IServiceCollection services = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => ServiceRegistrar.AddMediatRClassesWithTimeout(services, configuration));
+
+        Assert.Equal(nameof(services), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_mediatr_classes_with_timeout_when_configuration_is_null()
+    {
+        var services = new ServiceCollection();
+        MediatRServiceConfiguration configuration = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => ServiceRegistrar.AddMediatRClassesWithTimeout(services, configuration));
+
+        Assert.Equal(nameof(configuration), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_mediatr_classes_when_services_is_null()
+    {
+        IServiceCollection services = null!;
+        var configuration = new MediatRServiceConfiguration();
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => ServiceRegistrar.AddMediatRClasses(services, configuration, default(CancellationToken)));
+
+        Assert.Equal(nameof(services), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_mediatr_classes_when_configuration_is_null()
+    {
+        var services = new ServiceCollection();
+        MediatRServiceConfiguration configuration = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => ServiceRegistrar.AddMediatRClasses(services, configuration, default(CancellationToken)));
+
+        Assert.Equal(nameof(configuration), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_generate_combinations_when_request_type_is_null()
+    {
+        Type requestType = null!;
+        var lists = new List<List<Type>>();
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => ServiceRegistrar.GenerateCombinations(requestType, lists, 0, default(CancellationToken)));
+
+        Assert.Equal(nameof(requestType), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_generate_combinations_when_request_lists_is_null()
+    {
+        Type requestType = typeof(string);
+        List<List<Type>> lists = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => ServiceRegistrar.GenerateCombinations(requestType, lists, 0, default(CancellationToken)));
+
+        Assert.Equal(nameof(lists), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_required_services_when_services_is_null()
+    {
+        IServiceCollection services = null!;
+        var configuration = new MediatRServiceConfiguration();
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => ServiceRegistrar.AddRequiredServices(services, configuration));
+
+        Assert.Equal(nameof(services), exception.ParamName);
+    }
+
+    [Fact]
+    public void Should_throw_for_add_required_services_when_service_configuration_is_null()
+    {
+        var services = new ServiceCollection();
+        MediatRServiceConfiguration serviceConfiguration = null!;
+
+        var exception = Should.Throw<ArgumentNullException>(
+            () => ServiceRegistrar.AddRequiredServices(services, serviceConfiguration));
+
+        Assert.Equal(nameof(serviceConfiguration), exception.ParamName);
+    }
+}

--- a/test/MediatR.Tests/ArgumentNullExceptionTests/Wrappers/NotificationHandlerWrapperTests.cs
+++ b/test/MediatR.Tests/ArgumentNullExceptionTests/Wrappers/NotificationHandlerWrapperTests.cs
@@ -1,0 +1,61 @@
+﻿using MediatR.Wrappers;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MediatR.Tests.ArgumentNullExceptionTests.Wrappers;
+
+public class NotificationHandlerWrapperTests
+{
+    private class Pinged : INotification
+    {
+    }
+
+    [Fact]
+    public async Task Should_throw_for_handle_when_notification_is_null()
+    {
+        INotification notification = null!;
+        NotificationHandlerWrapperImpl<Pinged> notificationHandlerWrapperImpl = new();
+        var serviceCollection = new ServiceCollection();
+        var serviceFactory = serviceCollection.BuildServiceProvider();
+        Func<IEnumerable<NotificationHandlerExecutor>, INotification, CancellationToken, Task> publish = (_, _, _) => Task.CompletedTask;
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await notificationHandlerWrapperImpl.Handle(notification, serviceFactory, publish, CancellationToken.None));
+
+        Assert.Equal(nameof(notification), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_handle_when_service_factory_is_null()
+    {
+        var notification = new Pinged();
+        NotificationHandlerWrapperImpl<Pinged> notificationHandlerWrapperImpl = new();
+        IServiceProvider serviceFactory = null!;
+        Func<IEnumerable<NotificationHandlerExecutor>, INotification, CancellationToken, Task> publish = (_, _, _) => Task.CompletedTask;
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await notificationHandlerWrapperImpl.Handle(notification, serviceFactory, publish, CancellationToken.None));
+
+        Assert.Equal(nameof(serviceFactory), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_handle_when_publish_is_null()
+    {
+        var notification = new Pinged();
+        NotificationHandlerWrapperImpl<Pinged> notificationHandlerWrapperImpl = new();
+        var serviceCollection = new ServiceCollection();
+        var serviceFactory = serviceCollection.BuildServiceProvider();
+        Func<IEnumerable<NotificationHandlerExecutor>, INotification, CancellationToken, Task> publish = null!;
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await notificationHandlerWrapperImpl.Handle(notification, serviceFactory, publish, CancellationToken.None));
+
+        Assert.Equal(nameof(publish), exception.ParamName);
+    }
+}

--- a/test/MediatR.Tests/ArgumentNullExceptionTests/Wrappers/RequestHandlerBaseTests.cs
+++ b/test/MediatR.Tests/ArgumentNullExceptionTests/Wrappers/RequestHandlerBaseTests.cs
@@ -1,0 +1,123 @@
+﻿using MediatR.Wrappers;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MediatR.Tests.ArgumentNullExceptionTests.Wrappers;
+
+public class RequestHandlerBaseTests
+{
+    private sealed record CommandVoid : IRequest;
+    private sealed record Command : IRequest<string>;
+
+    [Fact]
+    public async Task Should_throw_for_handle_with_request_is_object_when_request_is_null()
+    {
+        var requestHandlerWrapperImpl = new RequestHandlerWrapperImpl<CommandVoid>();
+        object request = null!;
+        var serviceCollection = new ServiceCollection();
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await requestHandlerWrapperImpl.Handle(request, serviceProvider, CancellationToken.None));
+
+        Assert.Equal(nameof(request), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_handle_with_request_is_object_when_service_provider_is_null()
+    {
+        var requestHandlerWrapperImpl = new RequestHandlerWrapperImpl<CommandVoid>();
+        object request = new CommandVoid();
+        IServiceProvider serviceProvider = null!;
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await requestHandlerWrapperImpl.Handle(request, serviceProvider, CancellationToken.None));
+
+        Assert.Equal(nameof(serviceProvider), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_handle_when_request_is_null()
+    {
+        var requestHandlerWrapperImpl = new RequestHandlerWrapperImpl<CommandVoid>();
+        IRequest request = null!;
+        var serviceCollection = new ServiceCollection();
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await requestHandlerWrapperImpl.Handle(request, serviceProvider, CancellationToken.None));
+
+        Assert.Equal(nameof(request), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_handle_when_service_provider_is_null()
+    {
+        var requestHandlerWrapperImpl = new RequestHandlerWrapperImpl<CommandVoid>();
+        IRequest request = new CommandVoid();
+        IServiceProvider serviceProvider = null!;
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await requestHandlerWrapperImpl.Handle(request, serviceProvider, CancellationToken.None));
+
+        Assert.Equal(nameof(serviceProvider), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_void_handle_with_request_is_object_when_request_is_null()
+    {
+        var requestHandlerWrapperImpl = new RequestHandlerWrapperImpl<Command, string>();
+        object request = null!;
+        var serviceCollection = new ServiceCollection();
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await requestHandlerWrapperImpl.Handle(request, serviceProvider, CancellationToken.None));
+
+        Assert.Equal(nameof(request), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_void_handle_with_request_is_object_when_service_provider_is_null()
+    {
+        var requestHandlerWrapperImpl = new RequestHandlerWrapperImpl<Command, string>();
+        object request = new Command();
+        IServiceProvider serviceProvider = null!;
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await requestHandlerWrapperImpl.Handle(request, serviceProvider, CancellationToken.None));
+
+        Assert.Equal(nameof(serviceProvider), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_void_handle_when_request_is_null()
+    {
+        var requestHandlerWrapperImpl = new RequestHandlerWrapperImpl<Command, string>();
+        IRequest<string> request = null!;
+        var serviceCollection = new ServiceCollection();
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await requestHandlerWrapperImpl.Handle(request, serviceProvider, CancellationToken.None));
+
+        Assert.Equal(nameof(request), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task Should_throw_for_void_handle_when_service_provider_is_null()
+    {
+        var requestHandlerWrapperImpl = new RequestHandlerWrapperImpl<Command, string>();
+        IRequest<string> request = new Command();
+        IServiceProvider serviceProvider = null!;
+
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            async () => await requestHandlerWrapperImpl.Handle(request, serviceProvider, CancellationToken.None));
+
+        Assert.Equal(nameof(serviceProvider), exception.ParamName);
+    }
+}


### PR DESCRIPTION
Source [CA1062](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1062)

Cause
An externally visible method dereferences one of its reference arguments without verifying whether that argument is null (Nothing in Visual Basic).

You can [configure](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1062#configure-code-to-analyze) this rule to exclude certain types and parameters from analysis. You can also [indicate null-check validation methods](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1062#null-check-validation-methods).

Rule description
All reference arguments that are passed to externally visible methods should be checked against null. If appropriate, throw an [ArgumentNullException](https://learn.microsoft.com/en-us/dotnet/api/system.argumentnullexception) when the argument is null.

If a method can be called from an unknown assembly because it is declared public or protected, you should validate all parameters of the method. If the method is designed to be called only by known assemblies, mark the method internal and apply the [InternalsVisibleToAttribute](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.internalsvisibletoattribute) attribute to the assembly that contains the method.