### PR TITLE
Make Auto Registration of Generic Handlers OPT-IN

### DIFF
--- a/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
+++ b/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
@@ -92,7 +92,7 @@ public class MediatRServiceConfiguration
     /// <summary>
     /// Flag that controlls whether MediatR will attempt to register handlers that containg generic type parameters.
     /// </summary>
-    public bool RegisterGenericHandlers { get; set; } = true;
+    public bool RegisterGenericHandlers { get; set; } = false;
 
     /// <summary>
     /// Register various handlers from assembly containing given type

--- a/src/MediatR/Registration/ServiceRegistrar.cs
+++ b/src/MediatR/Registration/ServiceRegistrar.cs
@@ -230,9 +230,6 @@ public static class ServiceRegistrar
             .Select(x => x.GetGenericParameterConstraints())
             .ToList();
 
-        if (constraintsForEachParameter.Count > 2 && constraintsForEachParameter.Any(constraints => !constraints.Where(x => x.IsInterface || x.IsClass).Any()))
-            throw new ArgumentException($"Error registering the generic handler type: {openRequestHandlerImplementation.FullName}. When registering generic requests with more than two type parameters, each type parameter must have at least one constraint of type interface or class.");
-
         var typesThatCanCloseForEachParameter = constraintsForEachParameter
             .Select(constraints => assembliesToScan
                 .SelectMany(assembly => assembly.GetTypes())

--- a/test/MediatR.Tests/GenericRequestHandlerTests.cs
+++ b/test/MediatR.Tests/GenericRequestHandlerTests.cs
@@ -32,6 +32,7 @@ namespace MediatR.Tests
             services.AddMediatR(cfg =>
             {
                 cfg.RegisterServicesFromAssemblies(dynamicAssembly);
+                cfg.RegisterGenericHandlers = true;
             });
 
             var provider = services.BuildServiceProvider();
@@ -106,6 +107,7 @@ namespace MediatR.Tests
                 services.AddMediatR(cfg =>
                 {
                     cfg.RegisterServicesFromAssembly(assembly);
+                    cfg.RegisterGenericHandlers = true;
                 });
             })
             .Message.ShouldContain("One of the generic type parameter's count of types that can close exceeds the maximum length allowed");
@@ -124,6 +126,7 @@ namespace MediatR.Tests
                 services.AddMediatR(cfg =>
                 {
                     cfg.RegisterServicesFromAssembly(assembly);
+                    cfg.RegisterGenericHandlers = true;
                 });
             })
             .Message.ShouldContain("The total number of generic type registrations exceeds the maximum allowed");
@@ -142,6 +145,7 @@ namespace MediatR.Tests
                 services.AddMediatR(cfg =>
                 {
                     cfg.RegisterServicesFromAssembly(assembly);
+                    cfg.RegisterGenericHandlers = true;
                 });
             })
             .Message.ShouldContain("The number of generic type parameters exceeds the maximum allowed");
@@ -163,6 +167,7 @@ namespace MediatR.Tests
                     cfg.MaxGenericTypeRegistrations = 0;
                     cfg.MaxTypesClosing = 0;
                     cfg.RegistrationTimeout = 1000;
+                    cfg.RegisterGenericHandlers = true;
                     cfg.RegisterServicesFromAssembly(assembly);
                 });
             })

--- a/test/MediatR.Tests/GenericRequestHandlerTests.cs
+++ b/test/MediatR.Tests/GenericRequestHandlerTests.cs
@@ -94,24 +94,6 @@ namespace MediatR.Tests
         }
 
         [Fact]
-        public void ShouldThrowExceptionWhenRegisterningHandlersWithNoConstraints()
-        {
-            IServiceCollection services = new ServiceCollection();
-            services.AddSingleton(new Logger());
-
-            var assembly = GenerateMissingConstraintsAssembly();
-
-            Should.Throw<ArgumentException>(() =>
-            {
-                services.AddMediatR(cfg =>
-                {
-                    cfg.RegisterServicesFromAssembly(assembly);
-                });
-            })
-            .Message.ShouldContain("When registering generic requests with more than two type parameters, each type parameter must have at least one constraint of type interface or class.");
-        }
-
-        [Fact]
         public void ShouldThrowExceptionWhenTypesClosingExceedsMaximum()
         {
             IServiceCollection services = new ServiceCollection();

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/AssemblyResolutionTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/AssemblyResolutionTests.cs
@@ -15,7 +15,11 @@ public class AssemblyResolutionTests
     {
         IServiceCollection services = new ServiceCollection();
         services.AddSingleton(new Logger());
-        services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(Ping).Assembly));
+        services.AddMediatR(cfg =>
+        {
+            cfg.RegisterServicesFromAssembly(typeof(Ping).Assembly);
+            cfg.RegisterGenericHandlers = true;
+        });
         _provider = services.BuildServiceProvider();
     }
 

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/BaseGenericRequestHandlerTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/BaseGenericRequestHandlerTests.cs
@@ -9,11 +9,7 @@ using System.Threading.Tasks;
 namespace MediatR.Tests.MicrosoftExtensionsDI
 {
     public abstract class BaseGenericRequestHandlerTests
-    {      
-        
-        protected static Assembly GenerateMissingConstraintsAssembly() =>
-           CreateAssemblyModuleBuilder("MissingConstraintsAssembly", 3, 3, CreateHandlerForMissingConstraintsTest);
-
+    { 
         protected static Assembly GenerateTypesClosingExceedsMaximumAssembly() =>
             CreateAssemblyModuleBuilder("ExceedsMaximumTypesClosingAssembly", 201, 1, CreateHandlerForExceedsMaximumClassesTest);
 

--- a/test/MediatR.Tests/SendTests.cs
+++ b/test/MediatR.Tests/SendTests.cs
@@ -18,7 +18,11 @@ public class SendTests
     {
         _dependency = new Dependency();
         var services = new ServiceCollection();
-        services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(typeof(Ping).Assembly));
+        services.AddMediatR(cfg =>
+        {
+            cfg.RegisterServicesFromAssemblies(typeof(Ping).Assembly);
+            cfg.RegisterGenericHandlers = true;
+        });
         services.AddSingleton(_dependency);
         _serviceProvider = services.BuildServiceProvider();
         _mediator = _serviceProvider.GetService<IMediator>()!;
@@ -248,8 +252,13 @@ public class SendTests
     {
         var dependency = new Dependency();
         var services = new ServiceCollection();
-        services.AddSingleton(dependency);       
-        services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(Assembly.GetExecutingAssembly()));
+        services.AddSingleton(dependency);
+        services.AddMediatR(cfg =>
+        {
+            cfg.RegisterServicesFromAssemblies(Assembly.GetExecutingAssembly());
+            cfg.RegisterGenericHandlers = true;
+        });
+
         services.AddTransient<IRequestHandler<VoidGenericPing<PongExtension>>,TestClass1PingRequestHandler>();
         var serviceProvider = services.BuildServiceProvider();
         var mediator = serviceProvider.GetService<IMediator>()!;
@@ -267,7 +276,11 @@ public class SendTests
         var dependency = new Dependency();
         var services = new ServiceCollection();
         services.AddSingleton(dependency);
-        services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(Assembly.GetExecutingAssembly()));
+        services.AddMediatR(cfg => 
+        {
+            cfg.RegisterServicesFromAssemblies(Assembly.GetExecutingAssembly());
+            cfg.RegisterGenericHandlers = true;
+        });
         services.AddTransient<IRequestHandler<VoidGenericPing<PongExtension>>, TestClass1PingRequestHandler>();
         var serviceProvider = services.BuildServiceProvider();
         var mediator = serviceProvider.GetService<IMediator>()!;


### PR DESCRIPTION
- remove missing constraints logic.
- remove missing constraints tests.
- remove supporting method.
- make feature opt in via configuration

This is a direct fix for many people's issues regarding the enforcement of constraints for generic request handers having more than two generic type parameters. 

Direct fix for: #1055  , #1038

@jbogard  I have made this pr so that you can decide what you want to do. Either remove the feature completely or make it Opt-In until we can implement a better resolution strategy.
