### PR TITLE
Timeout behavior support

### DIFF
--- a/src/MediatR/IPipelineBehavior.cs
+++ b/src/MediatR/IPipelineBehavior.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 /// </summary>
 /// <typeparam name="TResponse">Response type</typeparam>
 /// <returns>Awaitable task returning a <typeparamref name="TResponse"/></returns>
-public delegate Task<TResponse> RequestHandlerDelegate<TResponse>();
+public delegate Task<TResponse> RequestHandlerDelegate<TResponse>(CancellationToken t = default);
 
 /// <summary>
 /// Pipeline behavior to surround the inner handler.

--- a/test/MediatR.Tests/SendTests.cs
+++ b/test/MediatR.Tests/SendTests.cs
@@ -6,6 +6,7 @@ using Shouldly;
 using Xunit;
 using Microsoft.Extensions.DependencyInjection;
 using System.Reflection;
+using MediatR.Pipeline;
 
 namespace MediatR.Tests;
 public class SendTests
@@ -18,7 +19,11 @@ public class SendTests
     {
         _dependency = new Dependency();
         var services = new ServiceCollection();
-        services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(typeof(Ping).Assembly));
+        services.AddMediatR(cfg =>
+        {
+            cfg.RegisterServicesFromAssemblies(typeof(Ping).Assembly);
+            cfg.AddOpenBehavior(typeof(TimeoutBehavior<,>), ServiceLifetime.Transient);
+        });
         services.AddSingleton(_dependency);
         _serviceProvider = services.BuildServiceProvider();
         _mediator = _serviceProvider.GetService<IMediator>()!;
@@ -131,7 +136,7 @@ public class SendTests
     public class TestClass2 : ITestInterface2 { }
     public class TestClass3 : ITestInterface3 { }
 
-    public class MultipleGenericTypeParameterRequest<T1, T2, T3> : IRequest<int> 
+    public class MultipleGenericTypeParameterRequest<T1, T2, T3> : IRequest<int>
        where T1 : ITestInterface1
        where T2 : ITestInterface2
        where T3 : ITestInterface3
@@ -152,6 +157,55 @@ public class SendTests
         {
             _dependency.Called = true;
             return Task.FromResult(1);
+        }
+    }
+
+    public class TimeoutBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+        where TRequest : notnull
+    {
+        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+        {
+            using (var cts = new CancellationTokenSource(500))
+            {
+                return await next(cts.Token);
+            }
+        }
+    }
+
+    public class TimeoutRequest : IRequest
+    {
+    }
+
+    public class TimeoutRequest2 : IRequest<int>
+    {
+    }
+
+    public class TimeoutRequestHandler : IRequestHandler<TimeoutRequest>
+    {
+        private readonly Dependency _dependency;
+
+        public TimeoutRequestHandler(Dependency dependency) => _dependency = dependency;
+
+        public async Task Handle(TimeoutRequest request, CancellationToken cancellationToken)
+        {
+            await Task.Delay(2000, cancellationToken);
+
+            _dependency.Called = true;
+        }
+    }
+
+    public class TimeoutRequest2Handler : IRequestHandler<TimeoutRequest2, int>
+    {
+        private readonly Dependency _dependency;
+
+        public TimeoutRequest2Handler(Dependency dependency) => _dependency = dependency;
+
+        public async Task<int> Handle(TimeoutRequest2 request, CancellationToken cancellationToken)
+        {
+            await Task.Delay(2000, cancellationToken);
+
+            _dependency.Called = true;
+            return 1;
         }
     }
 
@@ -248,9 +302,9 @@ public class SendTests
     {
         var dependency = new Dependency();
         var services = new ServiceCollection();
-        services.AddSingleton(dependency);       
+        services.AddSingleton(dependency);
         services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(Assembly.GetExecutingAssembly()));
-        services.AddTransient<IRequestHandler<VoidGenericPing<PongExtension>>,TestClass1PingRequestHandler>();
+        services.AddTransient<IRequestHandler<VoidGenericPing<PongExtension>>, TestClass1PingRequestHandler>();
         var serviceProvider = services.BuildServiceProvider();
         var mediator = serviceProvider.GetService<IMediator>()!;
 
@@ -277,5 +331,31 @@ public class SendTests
 
         dependency.Called.ShouldBeTrue();
         dependency.CalledSpecific.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task TimeoutBehavior_Void_Should_Cancel_Long_Running_Task_And_Throw_Exception()
+    {
+        var request = new TimeoutRequest();
+
+        var exception = await Should.ThrowAsync<TaskCanceledException>(() => _mediator.Send(request));
+
+        exception.ShouldNotBeNull();
+        exception.ShouldBeAssignableTo<TaskCanceledException>();
+        _dependency.Called.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task TimeoutBehavior_NonVoid_Should_Cancel_Long_Running_Task_And_Throw_Exception()
+    {
+        var request = new TimeoutRequest2();
+        int result = 0;
+
+        var exception = await Should.ThrowAsync<TaskCanceledException>(async () => { result = await _mediator.Send(request); });
+
+        exception.ShouldNotBeNull();
+        exception.ShouldBeAssignableTo<TaskCanceledException>();
+        _dependency.Called.ShouldBeFalse();
+        result.ShouldBe(0);
     }
 }


### PR DESCRIPTION
This PR adds support for creating a timeout behavior.

This PR is in direct response to #1056 , and the long discussion of  #592.  This was an older issue turned to discussion. I have solved the issue with the below implementation.

The below implementation modifies the `RequestHandlerDelegate` to take an optional `CancellationToken`.  I also modify the `RequestHandlerWrapperImpl` to match the delegate so the casting still works.  Then I modify the Aggregation to pass the token into the handle method for the next handler.

Usage:
```csharp
 public class TimeoutBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
     where TRequest : notnull
 {
     public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
         using (var cts = new CancellationTokenSource(someTimeoutDuration))
         {
             return await next(cts.Token);
         }
     }
 }
```

Test Handler:
```csharp
 public class TimeoutRequestHandler : IRequestHandler<TimeoutRequest>
 {
     private readonly Dependency _dependency;

     public TimeoutRequestHandler(Dependency dependency) => _dependency = dependency;

     public async Task Handle(TimeoutRequest request, CancellationToken cancellationToken)
     {
         await Task.Delay(someTimeThatIsLongerThanTheTimeoutDuration, cancellationToken);

         _dependency.Called = true;
     }
 }
```

Unit Test:
```csharp
 [Fact]
 public async Task TimeoutBehavior_Void_Should_Cancel_Long_Running_Task_And_Throw_Exception()
 {
     var request = new TimeoutRequest();

     var exception = await Should.ThrowAsync<TaskCanceledException>(() => _mediator.Send(request));

     exception.ShouldNotBeNull();
     exception.ShouldBeAssignableTo<TaskCanceledException>();
     _dependency.Called.ShouldBeFalse();
 }
```

