### PR TITLE
Open behavior multiple registration extensions

### DIFF
--- a/src/MediatR/Entities/OpenBehavior.cs
+++ b/src/MediatR/Entities/OpenBehavior.cs
@@ -1,0 +1,20 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MediatR.Entities;
+/// <summary>
+/// Creates open behavior entity.
+/// </summary>
+public class OpenBehavior
+{
+    public OpenBehavior(Type openBehaviorType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
+    {
+        OpenBehaviorType = openBehaviorType;
+        ServiceLifetime = serviceLifetime;
+    }
+
+    public Type? OpenBehaviorType { get; } 
+    public ServiceLifetime ServiceLifetime { get; }
+
+    
+}

--- a/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
+++ b/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using MediatR;
+using MediatR.Entities;
 using MediatR.NotificationPublishers;
 using MediatR.Pipeline;
 using MediatR.Registration;
@@ -222,6 +223,37 @@ public class MediatRServiceConfiguration
         return this;
     }
 
+    /// <summary>
+    /// Registers multiple open behavior types against the <see cref="IPipelineBehavior{TRequest,TResponse}"/> open generic interface type
+    /// </summary>
+    /// <param name="openBehaviorTypes">An open generic behavior type list includes multiple open generic behavior types.</param>
+    /// <param name="serviceLifetime">Optional service lifetime, defaults to <see cref="ServiceLifetime.Transient"/>.</param>
+    /// <returns>This</returns>
+    public MediatRServiceConfiguration AddOpenBehaviors(IEnumerable<Type> openBehaviorTypes, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
+    {
+        foreach (var openBehaviorType in openBehaviorTypes)
+        {
+            AddOpenBehavior(openBehaviorType, serviceLifetime);
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Registers open behaviors against the <see cref="IPipelineBehavior{TRequest,TResponse}"/> open generic interface type
+    /// </summary>
+    /// <param name="openBehaviors">An open generic behavior list includes multiple <see cref="OpenBehavior"/> open generic behaviors.</param>
+    /// <returns>This</returns>
+    public MediatRServiceConfiguration AddOpenBehaviors(IEnumerable<OpenBehavior> openBehaviors)
+    {
+        foreach (var openBehavior in openBehaviors)
+        {
+            AddOpenBehavior(openBehavior.OpenBehaviorType!, openBehavior.ServiceLifetime);
+        }
+
+        return this;
+    }
+    
     /// <summary>
     /// Register a closed stream behavior type
     /// </summary>


### PR DESCRIPTION
Hello,

I was adding multiple behaviors to my project and I didn't want to put my every behavior one by one like this:

```
services.AddMediatR(configuration =>
        {
            configuration.AddOpenBehavior(typeof(MyBehavior<,>));
            configuration.AddOpenBehavior(typeof(MyBehavior2<,>));
        });
```

so I decided to create my own AddBehaviors extension to add my behaviors by list at once. I thought this could help others without implementing their own extension.

Furthermore, I noticed there is a optional service lifetime implementation inside AddOpenBehavior so I added another extension with OpenBehavior entity. This helps developer to set every behavior service lifetime  individually while registering their behaviors with multiple registration.