### PR TITLE
Remove Generic Handler Support / Implementation (Leaving Failing Tests)

### DIFF
--- a/src/MediatR.Contracts/MediatR.Contracts.csproj
+++ b/src/MediatR.Contracts/MediatR.Contracts.csproj
@@ -6,7 +6,6 @@
     <Description>Contracts package for requests, responses, and notifications</Description>
     <Copyright>Copyright Jimmy Bogard</Copyright>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Nullable>enable</Nullable>
     <Features>strict</Features>
     <PackageTags>mediator;request;response;queries;commands;notifications</PackageTags>
     <SignAssembly>true</SignAssembly>

--- a/src/MediatR/Entities/OpenBehavior.cs
+++ b/src/MediatR/Entities/OpenBehavior.cs
@@ -1,0 +1,20 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MediatR.Entities;
+/// <summary>
+/// Creates open behavior entity.
+/// </summary>
+public class OpenBehavior
+{
+    public OpenBehavior(Type openBehaviorType, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
+    {
+        OpenBehaviorType = openBehaviorType;
+        ServiceLifetime = serviceLifetime;
+    }
+
+    public Type? OpenBehaviorType { get; } 
+    public ServiceLifetime ServiceLifetime { get; }
+
+    
+}

--- a/src/MediatR/IPipelineBehavior.cs
+++ b/src/MediatR/IPipelineBehavior.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 /// </summary>
 /// <typeparam name="TResponse">Response type</typeparam>
 /// <returns>Awaitable task returning a <typeparamref name="TResponse"/></returns>
-public delegate Task<TResponse> RequestHandlerDelegate<TResponse>();
+public delegate Task<TResponse> RequestHandlerDelegate<TResponse>(CancellationToken t = default);
 
 /// <summary>
 /// Pipeline behavior to surround the inner handler.

--- a/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
+++ b/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
@@ -15,7 +15,7 @@ public class MediatRServiceConfiguration
     /// Optional filter for types to register. Default value is a function returning true.
     /// </summary>
     public Func<Type, bool> TypeEvaluator { get; set; } = t => true;
-    
+
     /// <summary>
     /// Mediator implementation type to register. Default is <see cref="Mediator"/>
     /// </summary>
@@ -68,31 +68,6 @@ public class MediatRServiceConfiguration
     /// Automatically register processors during assembly scanning
     /// </summary>
     public bool AutoRegisterRequestProcessors { get; set; }
-
-    /// <summary>
-    /// Configure the maximum number of type parameters that a generic request handler can have. To Disable this constraint, set the value to 0.
-    /// </summary>
-    public int MaxGenericTypeParameters { get; set; } = 10;
-
-    /// <summary>
-    /// Configure the maximum number of types that can close a generic request type parameter constraint.  To Disable this constraint, set the value to 0.
-    /// </summary>
-    public int MaxTypesClosing { get; set; } = 100;
-
-    /// <summary>
-    /// Configure the Maximum Amount of Generic RequestHandler Types MediatR will try to register.  To Disable this constraint, set the value to 0.
-    /// </summary>
-    public int MaxGenericTypeRegistrations { get; set; } = 125000;
-
-    /// <summary>
-    /// Configure the Timeout in Milliseconds that the GenericHandler Registration Process will exit with error.  To Disable this constraint, set the value to 0.
-    /// </summary>
-    public int RegistrationTimeout { get; set; } = 15000;
-
-    /// <summary>
-    /// Flag that controlls whether MediatR will attempt to register handlers that containg generic type parameters.
-    /// </summary>
-    public bool RegisterGenericHandlers { get; set; } = false;
 
     /// <summary>
     /// Register various handlers from assembly containing given type
@@ -231,7 +206,7 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddStreamBehavior<TServiceType, TImplementationType>(ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
         => AddStreamBehavior(typeof(TServiceType), typeof(TImplementationType), serviceLifetime);
-    
+
     /// <summary>
     /// Register a closed stream behavior type
     /// </summary>
@@ -245,7 +220,7 @@ public class MediatRServiceConfiguration
 
         return this;
     }
-    
+
     /// <summary>
     /// Register a closed stream behavior type against all <see cref="IStreamPipelineBehavior{TRequest,TResponse}"/> implementations
     /// </summary>
@@ -254,7 +229,7 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddStreamBehavior<TImplementationType>(ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
         => AddStreamBehavior(typeof(TImplementationType), serviceLifetime);
-    
+
     /// <summary>
     /// Register a closed stream behavior type against all <see cref="IStreamPipelineBehavior{TRequest,TResponse}"/> implementations
     /// </summary>
@@ -277,7 +252,7 @@ public class MediatRServiceConfiguration
 
         return this;
     }
-    
+
     /// <summary>
     /// Registers an open stream behavior type against the <see cref="IStreamPipelineBehavior{TRequest,TResponse}"/> open generic interface type
     /// </summary>
@@ -316,7 +291,7 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddRequestPreProcessor<TServiceType, TImplementationType>(ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
         => AddRequestPreProcessor(typeof(TServiceType), typeof(TImplementationType), serviceLifetime);
-    
+
     /// <summary>
     /// Register a closed request pre processor type
     /// </summary>
@@ -360,10 +335,10 @@ public class MediatRServiceConfiguration
         {
             RequestPreProcessorsToRegister.Add(new ServiceDescriptor(implementedPreProcessorType, implementationType, serviceLifetime));
         }
-        
+
         return this;
     }
-    
+
     /// <summary>
     /// Registers an open request pre processor type against the <see cref="IRequestPreProcessor{TRequest}"/> open generic interface type
     /// </summary>
@@ -392,7 +367,7 @@ public class MediatRServiceConfiguration
 
         return this;
     }
-    
+
     /// <summary>
     /// Register a closed request post processor type
     /// </summary>
@@ -402,7 +377,7 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddRequestPostProcessor<TServiceType, TImplementationType>(ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
         => AddRequestPostProcessor(typeof(TServiceType), typeof(TImplementationType), serviceLifetime);
-    
+
     /// <summary>
     /// Register a closed request post processor type
     /// </summary>
@@ -416,7 +391,7 @@ public class MediatRServiceConfiguration
 
         return this;
     }
- 
+
     /// <summary>
     /// Register a closed request post processor type against all <see cref="IRequestPostProcessor{TRequest,TResponse}"/> implementations
     /// </summary>
@@ -425,7 +400,7 @@ public class MediatRServiceConfiguration
     /// <returns>This</returns>
     public MediatRServiceConfiguration AddRequestPostProcessor<TImplementationType>(ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
         => AddRequestPostProcessor(typeof(TImplementationType), serviceLifetime);
-    
+
     /// <summary>
     /// Register a closed request post processor type against all <see cref="IRequestPostProcessor{TRequest,TResponse}"/> implementations
     /// </summary>
@@ -447,7 +422,7 @@ public class MediatRServiceConfiguration
         }
         return this;
     }
-    
+
     /// <summary>
     /// Registers an open request post processor type against the <see cref="IRequestPostProcessor{TRequest,TResponse}"/> open generic interface type
     /// </summary>

--- a/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
+++ b/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using MediatR;
+using MediatR.Entities;
 using MediatR.NotificationPublishers;
 using MediatR.Pipeline;
 using MediatR.Registration;
@@ -197,6 +198,37 @@ public class MediatRServiceConfiguration
         return this;
     }
 
+    /// <summary>
+    /// Registers multiple open behavior types against the <see cref="IPipelineBehavior{TRequest,TResponse}"/> open generic interface type
+    /// </summary>
+    /// <param name="openBehaviorTypes">An open generic behavior type list includes multiple open generic behavior types.</param>
+    /// <param name="serviceLifetime">Optional service lifetime, defaults to <see cref="ServiceLifetime.Transient"/>.</param>
+    /// <returns>This</returns>
+    public MediatRServiceConfiguration AddOpenBehaviors(IEnumerable<Type> openBehaviorTypes, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
+    {
+        foreach (var openBehaviorType in openBehaviorTypes)
+        {
+            AddOpenBehavior(openBehaviorType, serviceLifetime);
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Registers open behaviors against the <see cref="IPipelineBehavior{TRequest,TResponse}"/> open generic interface type
+    /// </summary>
+    /// <param name="openBehaviors">An open generic behavior list includes multiple <see cref="OpenBehavior"/> open generic behaviors.</param>
+    /// <returns>This</returns>
+    public MediatRServiceConfiguration AddOpenBehaviors(IEnumerable<OpenBehavior> openBehaviors)
+    {
+        foreach (var openBehavior in openBehaviors)
+        {
+            AddOpenBehavior(openBehavior.OpenBehaviorType!, openBehavior.ServiceLifetime);
+        }
+
+        return this;
+    }
+    
     /// <summary>
     /// Register a closed stream behavior type
     /// </summary>

--- a/src/MediatR/MicrosoftExtensionsDI/ServiceCollectionExtensions.cs
+++ b/src/MediatR/MicrosoftExtensionsDI/ServiceCollectionExtensions.cs
@@ -23,7 +23,7 @@ public static class ServiceCollectionExtensions
     /// <param name="services">Service collection</param>
     /// <param name="configuration">The action used to configure the options</param>
     /// <returns>Service collection</returns>
-    public static IServiceCollection AddMediatR(this IServiceCollection services, 
+    public static IServiceCollection AddMediatR(this IServiceCollection services,
         Action<MediatRServiceConfiguration> configuration)
     {
         var serviceConfig = new MediatRServiceConfiguration();
@@ -32,14 +32,14 @@ public static class ServiceCollectionExtensions
 
         return services.AddMediatR(serviceConfig);
     }
-    
+
     /// <summary>
     /// Registers handlers and mediator types from the specified assemblies
     /// </summary>
     /// <param name="services">Service collection</param>
     /// <param name="configuration">Configuration options</param>
     /// <returns>Service collection</returns>
-    public static IServiceCollection AddMediatR(this IServiceCollection services, 
+    public static IServiceCollection AddMediatR(this IServiceCollection services,
         MediatRServiceConfiguration configuration)
     {
         if (!configuration.AssembliesToRegister.Any())
@@ -47,9 +47,7 @@ public static class ServiceCollectionExtensions
             throw new ArgumentException("No assemblies found to scan. Supply at least one assembly to scan for handlers.");
         }
 
-        ServiceRegistrar.SetGenericRequestHandlerRegistrationLimitations(configuration);
-
-        ServiceRegistrar.AddMediatRClassesWithTimeout(services, configuration);
+        ServiceRegistrar.AddMediatRClasses(services, configuration);
 
         ServiceRegistrar.AddRequiredServices(services, configuration);
 

--- a/test/MediatR.Tests/GenericRequestHandlerTests.cs
+++ b/test/MediatR.Tests/GenericRequestHandlerTests.cs
@@ -32,7 +32,7 @@ namespace MediatR.Tests
             services.AddMediatR(cfg =>
             {
                 cfg.RegisterServicesFromAssemblies(dynamicAssembly);
-                cfg.RegisterGenericHandlers = true;
+               // cfg.RegisterGenericHandlers = true;
             });
 
             var provider = services.BuildServiceProvider();
@@ -107,7 +107,7 @@ namespace MediatR.Tests
                 services.AddMediatR(cfg =>
                 {
                     cfg.RegisterServicesFromAssembly(assembly);
-                    cfg.RegisterGenericHandlers = true;
+                    //cfg.RegisterGenericHandlers = true;
                 });
             })
             .Message.ShouldContain("One of the generic type parameter's count of types that can close exceeds the maximum length allowed");
@@ -126,7 +126,7 @@ namespace MediatR.Tests
                 services.AddMediatR(cfg =>
                 {
                     cfg.RegisterServicesFromAssembly(assembly);
-                    cfg.RegisterGenericHandlers = true;
+                    //cfg.RegisterGenericHandlers = true;
                 });
             })
             .Message.ShouldContain("The total number of generic type registrations exceeds the maximum allowed");
@@ -145,7 +145,7 @@ namespace MediatR.Tests
                 services.AddMediatR(cfg =>
                 {
                     cfg.RegisterServicesFromAssembly(assembly);
-                    cfg.RegisterGenericHandlers = true;
+                   // cfg.RegisterGenericHandlers = true;
                 });
             })
             .Message.ShouldContain("The number of generic type parameters exceeds the maximum allowed");
@@ -163,11 +163,11 @@ namespace MediatR.Tests
             {
                 services.AddMediatR(cfg =>
                 {
-                    cfg.MaxGenericTypeParameters = 0;
-                    cfg.MaxGenericTypeRegistrations = 0;
-                    cfg.MaxTypesClosing = 0;
-                    cfg.RegistrationTimeout = 1000;
-                    cfg.RegisterGenericHandlers = true;
+                    //cfg.MaxGenericTypeParameters = 0;
+                    //cfg.MaxGenericTypeRegistrations = 0;
+                    //cfg.MaxTypesClosing = 0;
+                    //cfg.RegistrationTimeout = 1000;
+                    //cfg.RegisterGenericHandlers = true;
                     cfg.RegisterServicesFromAssembly(assembly);
                 });
             })
@@ -184,7 +184,7 @@ namespace MediatR.Tests
             services.AddMediatR(cfg =>
             {
                 //opt out flag set
-                cfg.RegisterGenericHandlers = false;
+                //cfg.RegisterGenericHandlers = false;
                 cfg.RegisterServicesFromAssembly(assembly);
             });
 

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/AssemblyResolutionTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/AssemblyResolutionTests.cs
@@ -18,7 +18,7 @@ public class AssemblyResolutionTests
         services.AddMediatR(cfg =>
         {
             cfg.RegisterServicesFromAssembly(typeof(Ping).Assembly);
-            cfg.RegisterGenericHandlers = true;
+            //cfg.RegisterGenericHandlers = true;
         });
         _provider = services.BuildServiceProvider();
     }

--- a/test/MediatR.Tests/SendTests.cs
+++ b/test/MediatR.Tests/SendTests.cs
@@ -21,7 +21,7 @@ public class SendTests
         services.AddMediatR(cfg =>
         {
             cfg.RegisterServicesFromAssemblies(typeof(Ping).Assembly);
-            cfg.RegisterGenericHandlers = true;
+            //cfg.RegisterGenericHandlers = true;
         });
         services.AddSingleton(_dependency);
         _serviceProvider = services.BuildServiceProvider();
@@ -256,7 +256,7 @@ public class SendTests
         services.AddMediatR(cfg =>
         {
             cfg.RegisterServicesFromAssemblies(Assembly.GetExecutingAssembly());
-            cfg.RegisterGenericHandlers = true;
+            //cfg.RegisterGenericHandlers = true;
         });
 
         services.AddTransient<IRequestHandler<VoidGenericPing<PongExtension>>,TestClass1PingRequestHandler>();
@@ -279,7 +279,7 @@ public class SendTests
         services.AddMediatR(cfg => 
         {
             cfg.RegisterServicesFromAssemblies(Assembly.GetExecutingAssembly());
-            cfg.RegisterGenericHandlers = true;
+            //cfg.RegisterGenericHandlers = true;
         });
         services.AddTransient<IRequestHandler<VoidGenericPing<PongExtension>>, TestClass1PingRequestHandler>();
         var serviceProvider = services.BuildServiceProvider();

--- a/test/MediatR.Tests/SendTests.cs
+++ b/test/MediatR.Tests/SendTests.cs
@@ -6,6 +6,7 @@ using Shouldly;
 using Xunit;
 using Microsoft.Extensions.DependencyInjection;
 using System.Reflection;
+using MediatR.Pipeline;
 
 namespace MediatR.Tests;
 public class SendTests
@@ -22,6 +23,7 @@ public class SendTests
         {
             cfg.RegisterServicesFromAssemblies(typeof(Ping).Assembly);
             //cfg.RegisterGenericHandlers = true;
+            cfg.AddOpenBehavior(typeof(TimeoutBehavior<,>), ServiceLifetime.Transient);
         });
         services.AddSingleton(_dependency);
         _serviceProvider = services.BuildServiceProvider();
@@ -135,7 +137,7 @@ public class SendTests
     public class TestClass2 : ITestInterface2 { }
     public class TestClass3 : ITestInterface3 { }
 
-    public class MultipleGenericTypeParameterRequest<T1, T2, T3> : IRequest<int> 
+    public class MultipleGenericTypeParameterRequest<T1, T2, T3> : IRequest<int>
        where T1 : ITestInterface1
        where T2 : ITestInterface2
        where T3 : ITestInterface3
@@ -156,6 +158,55 @@ public class SendTests
         {
             _dependency.Called = true;
             return Task.FromResult(1);
+        }
+    }
+
+    public class TimeoutBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+        where TRequest : notnull
+    {
+        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+        {
+            using (var cts = new CancellationTokenSource(500))
+            {
+                return await next(cts.Token);
+            }
+        }
+    }
+
+    public class TimeoutRequest : IRequest
+    {
+    }
+
+    public class TimeoutRequest2 : IRequest<int>
+    {
+    }
+
+    public class TimeoutRequestHandler : IRequestHandler<TimeoutRequest>
+    {
+        private readonly Dependency _dependency;
+
+        public TimeoutRequestHandler(Dependency dependency) => _dependency = dependency;
+
+        public async Task Handle(TimeoutRequest request, CancellationToken cancellationToken)
+        {
+            await Task.Delay(2000, cancellationToken);
+
+            _dependency.Called = true;
+        }
+    }
+
+    public class TimeoutRequest2Handler : IRequestHandler<TimeoutRequest2, int>
+    {
+        private readonly Dependency _dependency;
+
+        public TimeoutRequest2Handler(Dependency dependency) => _dependency = dependency;
+
+        public async Task<int> Handle(TimeoutRequest2 request, CancellationToken cancellationToken)
+        {
+            await Task.Delay(2000, cancellationToken);
+
+            _dependency.Called = true;
+            return 1;
         }
     }
 
@@ -290,5 +341,31 @@ public class SendTests
 
         dependency.Called.ShouldBeTrue();
         dependency.CalledSpecific.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task TimeoutBehavior_Void_Should_Cancel_Long_Running_Task_And_Throw_Exception()
+    {
+        var request = new TimeoutRequest();
+
+        var exception = await Should.ThrowAsync<TaskCanceledException>(() => _mediator.Send(request));
+
+        exception.ShouldNotBeNull();
+        exception.ShouldBeAssignableTo<TaskCanceledException>();
+        _dependency.Called.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task TimeoutBehavior_NonVoid_Should_Cancel_Long_Running_Task_And_Throw_Exception()
+    {
+        var request = new TimeoutRequest2();
+        int result = 0;
+
+        var exception = await Should.ThrowAsync<TaskCanceledException>(async () => { result = await _mediator.Send(request); });
+
+        exception.ShouldNotBeNull();
+        exception.ShouldBeAssignableTo<TaskCanceledException>();
+        _dependency.Called.ShouldBeFalse();
+        result.ShouldBe(0);
     }
 }


### PR DESCRIPTION
This PR removes the Generic Handler Support / Implementation and leaves the failing tests for future development / support behaviors as requested from @jbogard 

I can't say that I agree with this approach.  I feel like it would be better to leave the current implementation in while a better implementation is developed.  It doesn't really make sense to add the feature then remove it just to re-add it again in the future when someone can develop it in the way you are wanting.  I feel like it's better to just leave the working implementation in the opt in paradigm (opt in feature flag sort of behavior) and let people try to develop in a better way while the current feature is working.  That is more of a "Red, Green, Refactor" approach. It doesn't really make sense to me to remove a feature that :

1. isn't hurting anything (since it is now opt in) 
2. is currently meeting the test criteria that you want the feature to meet.

Those are my thoughts and opinions on it. However, this isn't my choice to make and that is fine.

Cheers. 