### PR TITLE
Update setup-dotnet package version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
       with:
         fetch-depth: 0
     - name: Setup dotnet 6.0
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '6.0.x'
     - name: Setup dotnet 8.0
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '8.0.100'
     - name: Build and Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ jobs:
       with:
         fetch-depth: 0
     - name: Setup dotnet 6.0
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '6.0.x'
     - name: Setup dotnet 8.0
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '8.0.100'
     - name: Build and Test


### PR DESCRIPTION
Updated dotnet action setup workflows to fix github actions error `Error: Request timeout: /dotnet/release-metadata/releases-index.json`.