### PR TITLE
Optimize Generic Handler Registration in MediatR

### DIFF
--- a/src/MediatR/MediatR.csproj
+++ b/src/MediatR/MediatR.csproj
@@ -34,6 +34,7 @@
     </PackageReference>
     <PackageReference Include="MediatR.Contracts" Version="[2.0.1, 3.0.0)" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="4.3.0" PrivateAssets="All" />

--- a/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
+++ b/src/MediatR/MicrosoftExtensionsDI/MediatrServiceConfiguration.cs
@@ -69,27 +69,7 @@ public class MediatRServiceConfiguration
     /// Automatically register processors during assembly scanning
     /// </summary>
     public bool AutoRegisterRequestProcessors { get; set; }
-
-    /// <summary>
-    /// Configure the maximum number of type parameters that a generic request handler can have. To Disable this constraint, set the value to 0.
-    /// </summary>
-    public int MaxGenericTypeParameters { get; set; } = 10;
-
-    /// <summary>
-    /// Configure the maximum number of types that can close a generic request type parameter constraint.  To Disable this constraint, set the value to 0.
-    /// </summary>
-    public int MaxTypesClosing { get; set; } = 100;
-
-    /// <summary>
-    /// Configure the Maximum Amount of Generic RequestHandler Types MediatR will try to register.  To Disable this constraint, set the value to 0.
-    /// </summary>
-    public int MaxGenericTypeRegistrations { get; set; } = 125000;
-
-    /// <summary>
-    /// Configure the Timeout in Milliseconds that the GenericHandler Registration Process will exit with error.  To Disable this constraint, set the value to 0.
-    /// </summary>
-    public int RegistrationTimeout { get; set; } = 15000;
-
+        
     /// <summary>
     /// Flag that controlls whether MediatR will attempt to register handlers that containg generic type parameters.
     /// </summary>

--- a/src/MediatR/MicrosoftExtensionsDI/ServiceCollectionExtensions.cs
+++ b/src/MediatR/MicrosoftExtensionsDI/ServiceCollectionExtensions.cs
@@ -47,11 +47,14 @@ public static class ServiceCollectionExtensions
             throw new ArgumentException("No assemblies found to scan. Supply at least one assembly to scan for handlers.");
         }
 
-        ServiceRegistrar.SetGenericRequestHandlerRegistrationLimitations(configuration);
-
-        ServiceRegistrar.AddMediatRClassesWithTimeout(services, configuration);
+        ServiceRegistrar.AddMediatRClasses(services, configuration);
 
         ServiceRegistrar.AddRequiredServices(services, configuration);
+
+        if (configuration.RegisterGenericHandlers)
+        {
+            ServiceRegistrar.AddDynamicServiceProvider(services, configuration);
+        }
 
         return services;
     }

--- a/src/MediatR/Registration/DynamicServiceProvider.cs
+++ b/src/MediatR/Registration/DynamicServiceProvider.cs
@@ -1,0 +1,210 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace MediatR.Registration
+{
+    public class DynamicServiceProvider : IServiceProvider, IDisposable
+    {
+        private readonly IServiceProvider _rootProvider;
+        private ServiceProvider _currentProvider;
+        private readonly IServiceCollection _services;
+        private readonly Type[] RequestHandlerTypes = new Type[] { typeof(IRequestHandler<>), typeof(IRequestHandler<,>) };
+
+        public DynamicServiceProvider(IServiceProvider rootProvider)
+        {
+            _rootProvider = rootProvider;
+            _services = new ServiceCollection();
+            _currentProvider = _services.BuildServiceProvider();
+        }
+
+        public IEnumerable<ServiceDescriptor> GetAllServiceDescriptors()
+        {
+            return _services; 
+        }
+
+        public void AddService(Type serviceType, Type implementationType, ServiceLifetime lifetime = ServiceLifetime.Transient)
+        {
+            var constructor = implementationType.GetConstructors().OrderByDescending(c => c.GetParameters().Length).FirstOrDefault();
+            if (constructor != null)
+            {
+                var parameters = constructor.GetParameters();
+
+                foreach (var parameter in parameters)
+                {
+                    // Check if the dependency is already registered
+                    if (_currentProvider.GetService(parameter.ParameterType) != null)
+                        continue;
+
+                    // Attempt to resolve from the root provider
+                    var dependency = _rootProvider.GetService(parameter.ParameterType);
+                    if (dependency != null)
+                    {   
+                        // Dynamically register the dependency in the dynamic registry
+                        _services.Add(new ServiceDescriptor(parameter.ParameterType, _ => dependency, lifetime));
+                        RebuildProvider(); // Rebuild the internal provider to include the new service
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException(
+                            $"Unable to resolve dependency {parameter.ParameterType.FullName} for {serviceType.FullName}");
+                    }
+                }
+            }
+            _services.Add(new ServiceDescriptor(serviceType, implementationType, lifetime));
+            RebuildProvider();
+        }
+
+        public void AddService(Type serviceType, Func<IServiceProvider, object> implementationFactory, ServiceLifetime lifetime = ServiceLifetime.Transient)
+        {
+            if (serviceType == null) throw new ArgumentNullException(nameof(serviceType));
+            if (implementationFactory == null) throw new ArgumentNullException(nameof(implementationFactory));
+
+            // Add the service descriptor with the factory
+            _services.Add(new ServiceDescriptor(serviceType, implementationFactory, lifetime));
+            RebuildProvider();
+        }
+
+        //public IServiceProvider RootProvider { get { return _rootProvider; } }
+        public object? GetService(Type serviceType)
+        {
+            // Handle requests for IEnumerable<T>
+            if (serviceType.IsGenericType && serviceType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            {
+                // typeof(T) for IEnumerable<T>
+                var elementType = serviceType.GenericTypeArguments[0];
+                return CastToEnumerableOfType(GetServices(elementType), elementType);
+            }
+
+            // Try resolving from the current provider
+            var service = _currentProvider.GetService(serviceType);
+            if (service != null) return service;
+
+            //fall back to root provider
+            service = _rootProvider.GetService(serviceType);
+            if(service != null) return service;
+
+            //if not found in current or root then try to find the implementation and register it.
+            if (serviceType.IsGenericType)
+            {
+                var genericArguments = serviceType.GetGenericArguments();
+                var hasResponseType = genericArguments.Length > 1;
+                var openInterface = hasResponseType ? typeof(IRequestHandler<,>) : typeof(IRequestHandler<>);
+
+                if(openInterface != null)
+                {   
+                    var requestType = genericArguments[0];                   
+                    Type? responseType = hasResponseType ? genericArguments[1] : null;
+                    
+                    var implementationType = FindOpenGenericHandlerType(requestType, responseType);
+                    if(implementationType == null)
+                        throw new InvalidOperationException($"No implementation found for {openInterface.FullName}");
+
+                    AddService(serviceType, implementationType);
+                }
+            }
+
+            //find the newly registered service
+            service = _currentProvider.GetService(serviceType);
+            if (service != null) return service;
+            
+            // Fallback to the root provider as a last resort
+            return _rootProvider.GetService(serviceType);            
+        }
+
+        public IEnumerable<object> GetServices(Type serviceType)
+        {
+            // Collect services from the dynamic provider
+            var dynamicServices = _services
+                .Where(d => d.ServiceType == serviceType)
+                .Select(d => _currentProvider.GetService(d.ServiceType))
+                .Where(s => s != null);
+
+            // Collect services from the root provider
+            var rootServices = _rootProvider
+                .GetServices(serviceType)
+                .Cast<object>();
+
+            // Combine results and remove duplicates
+            return dynamicServices.Concat(rootServices).Distinct()!;
+        }
+
+        private object CastToEnumerableOfType(IEnumerable<object> services, Type elementType)
+        {
+            var castMethod = typeof(Enumerable)
+                .GetMethod(nameof(Enumerable.Cast))
+                ?.MakeGenericMethod(elementType);
+
+            var toListMethod = typeof(Enumerable)
+                .GetMethod(nameof(Enumerable.ToList))
+                ?.MakeGenericMethod(elementType);
+
+            if (castMethod == null || toListMethod == null)
+                throw new InvalidOperationException("Unable to cast services to the specified enumerable type.");
+
+            var castedServices = castMethod.Invoke(null, new object[] { services });
+            return toListMethod.Invoke(null, new[] { castedServices })!;
+        }
+
+        public Type? FindOpenGenericHandlerType(Type requestType, Type? responseType = null)
+        {
+            if (!requestType.IsGenericType)
+                return null;
+
+            // Define the target generic handler type
+            var openHandlerType = responseType == null ? typeof(IRequestHandler<>) : typeof(IRequestHandler<,>);
+            var genericArguments = responseType == null ? new Type[] { requestType } : new Type[] { requestType, responseType };
+            var closedHandlerType = openHandlerType.MakeGenericType(genericArguments);
+
+            // Get the current assembly
+            var currentAssembly = Assembly.GetExecutingAssembly();
+
+            // Get assemblies that reference the current assembly
+            var consumingAssemblies = AppDomain.CurrentDomain.GetAssemblies()
+                .Where(assembly => assembly.GetReferencedAssemblies()
+                    .Any(reference => reference.FullName == currentAssembly.FullName));
+
+            // Search for matching types
+            var types = consumingAssemblies.SelectMany(x => x.GetTypes())
+                .Where(t => t.IsClass && !t.IsAbstract && t.IsGenericTypeDefinition)
+                .ToList();
+
+            foreach (var type in types)
+            {
+                var interfaces = type.GetInterfaces();
+                if (interfaces.Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == openHandlerType))
+                {
+                    // Check generic constraints
+                    var concreteHandlerGenericArgs = type.GetGenericArguments();
+                    var concreteHandlerConstraints = concreteHandlerGenericArgs.Select(x => x.GetGenericParameterConstraints());
+                    var concreteRequestTypeGenericArgs = requestType.GetGenericArguments();
+                    //var secondArgConstrants = genericArguments[1];
+
+                    // Ensure the constraints are compatible
+                    if (concreteHandlerConstraints
+                        .Select((list, i) => new { List = list, Index = i })
+                        .All(x => x.List.All(c => c.IsAssignableFrom(concreteRequestTypeGenericArgs[x.Index]))))
+                    {
+                        return type.MakeGenericType(concreteRequestTypeGenericArgs);
+                    }
+                }
+            }
+
+            return null; // No matching type found
+        }
+
+        private void RebuildProvider()
+        {
+            _currentProvider.Dispose();
+            _currentProvider = _services.BuildServiceProvider();
+        }
+
+        public void Dispose()
+        {
+            _currentProvider.Dispose();
+        }
+    }
+}

--- a/src/MediatR/Registration/ServiceRegistrar.cs
+++ b/src/MediatR/Registration/ServiceRegistrar.cs
@@ -11,41 +11,12 @@ namespace MediatR.Registration;
 
 public static class ServiceRegistrar
 {
-    private static int MaxGenericTypeParameters;
-    private static int MaxTypesClosing;
-    private static int MaxGenericTypeRegistrations;
-    private static int RegistrationTimeout; 
-
-    public static void SetGenericRequestHandlerRegistrationLimitations(MediatRServiceConfiguration configuration)
+    public static void AddMediatRClasses(IServiceCollection services, MediatRServiceConfiguration configuration)
     {
-        MaxGenericTypeParameters = configuration.MaxGenericTypeParameters;
-        MaxTypesClosing = configuration.MaxTypesClosing;
-        MaxGenericTypeRegistrations = configuration.MaxGenericTypeRegistrations;
-        RegistrationTimeout = configuration.RegistrationTimeout;
-    }
-
-    public static void AddMediatRClassesWithTimeout(IServiceCollection services, MediatRServiceConfiguration configuration)
-    {
-        using(var cts = new CancellationTokenSource(RegistrationTimeout))
-        {
-            try
-            {
-                AddMediatRClasses(services, configuration, cts.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                throw new TimeoutException("The generic handler registration process timed out.");
-            }
-        }
-    }
-
-    public static void AddMediatRClasses(IServiceCollection services, MediatRServiceConfiguration configuration, CancellationToken cancellationToken = default)
-    {   
-
         var assembliesToScan = configuration.AssembliesToRegister.Distinct().ToArray();
 
-        ConnectImplementationsToTypesClosing(typeof(IRequestHandler<,>), services, assembliesToScan, false, configuration, cancellationToken);
-        ConnectImplementationsToTypesClosing(typeof(IRequestHandler<>), services, assembliesToScan, false, configuration, cancellationToken);
+        ConnectImplementationsToTypesClosing(typeof(IRequestHandler<,>), services, assembliesToScan, false, configuration);
+        ConnectImplementationsToTypesClosing(typeof(IRequestHandler<>), services, assembliesToScan, false, configuration);
         ConnectImplementationsToTypesClosing(typeof(INotificationHandler<>), services, assembliesToScan, true, configuration);
         ConnectImplementationsToTypesClosing(typeof(IStreamRequestHandler<,>), services, assembliesToScan, false, configuration);
         ConnectImplementationsToTypesClosing(typeof(IRequestExceptionHandler<,,>), services, assembliesToScan, true, configuration);
@@ -89,81 +60,67 @@ public static class ServiceRegistrar
         }
     }
 
-    private static void ConnectImplementationsToTypesClosing(Type openRequestInterface,
-        IServiceCollection services,
-        IEnumerable<Assembly> assembliesToScan,
-        bool addIfAlreadyExists,
-        MediatRServiceConfiguration configuration,
-        CancellationToken cancellationToken = default)
+    private static void ConnectImplementationsToTypesClosing(
+    Type openRequestInterface,
+    IServiceCollection services,
+    IEnumerable<Assembly> assembliesToScan,
+    bool addIfAlreadyExists,
+    MediatRServiceConfiguration configuration)
     {
         var concretions = new List<Type>();
-        var interfaces = new List<Type>();
-        var genericConcretions = new List<Type>();
-        var genericInterfaces = new List<Type>();
+        var interfaces = new HashSet<Type>(); // Use HashSet to avoid duplicates
 
-        var types = assembliesToScan
+        foreach (var type in assembliesToScan
             .SelectMany(a => a.DefinedTypes)
-            .Where(t => !t.ContainsGenericParameters || configuration.RegisterGenericHandlers)
-            .Where(t => t.IsConcrete() && t.FindInterfacesThatClose(openRequestInterface).Any())
-            .Where(configuration.TypeEvaluator)
-            .ToList();        
-
-        foreach (var type in types)
+            .Where(t => !t.IsOpenGeneric() && configuration.TypeEvaluator(t)))
         {
-            var interfaceTypes = type.FindInterfacesThatClose(openRequestInterface).ToArray();
+            var interfaceTypes = type.FindInterfacesThatClose(openRequestInterface);
+            if (!interfaceTypes.Any()) continue;
 
-            if (!type.IsOpenGeneric())
-            {
-                concretions.Add(type);
+            if (type.IsConcrete()) concretions.Add(type);
 
-                foreach (var interfaceType in interfaceTypes)
-                {
-                    interfaces.Fill(interfaceType);
-                }
-            }
-            else
+            foreach (var interfaceType in interfaceTypes)
             {
-                genericConcretions.Add(type);
-                foreach (var interfaceType in interfaceTypes)
-                {
-                    genericInterfaces.Fill(interfaceType);
-                }
+                interfaces.Add(interfaceType);
             }
         }
 
         foreach (var @interface in interfaces)
         {
-            var exactMatches = concretions.Where(x => x.CanBeCastTo(@interface)).ToList();
-            if (addIfAlreadyExists)
-            {
-                foreach (var type in exactMatches)
-                {
-                    services.AddTransient(@interface, type);
-                }
-            }
-            else
-            {
-                if (exactMatches.Count > 1)
-                {
-                    exactMatches.RemoveAll(m => !IsMatchingWithInterface(m, @interface));
-                }
-
-                foreach (var type in exactMatches)
-                {
-                    services.TryAddTransient(@interface, type);
-                }
-            }
+            RegisterImplementationsForInterface(@interface, concretions, services, addIfAlreadyExists);
 
             if (!@interface.IsOpenGeneric())
             {
                 AddConcretionsThatCouldBeClosed(@interface, concretions, services);
             }
         }
+    }
 
-        foreach (var @interface in genericInterfaces)
+    private static void RegisterImplementationsForInterface(
+        Type @interface,
+        List<Type> concretions,
+        IServiceCollection services,
+        bool addIfAlreadyExists)
+    {
+        var exactMatches = concretions.Where(x => x.CanBeCastTo(@interface)).ToList();
+
+        if (addIfAlreadyExists)
         {
-            var exactMatches = genericConcretions.Where(x => x.CanBeCastTo(@interface)).ToList();
-            AddAllConcretionsThatClose(@interface, exactMatches, services, assembliesToScan, cancellationToken);
+            foreach (var type in exactMatches)
+            {
+                services.AddTransient(@interface, type);
+            }
+        }
+        else
+        {
+            if (exactMatches.Count > 1)
+            {
+                exactMatches.RemoveAll(m => !IsMatchingWithInterface(m, @interface));
+            }
+            foreach (var type in exactMatches)
+            {
+                services.TryAddTransient(@interface, type);
+            }
         }
     }
 
@@ -200,117 +157,6 @@ public static class ServiceRegistrar
             }
             catch (Exception)
             {
-            }
-        }
-    }
-
-    private static (Type Service, Type Implementation) GetConcreteRegistrationTypes(Type openRequestHandlerInterface, Type concreteGenericTRequest, Type openRequestHandlerImplementation)
-    {
-        var closingTypes = concreteGenericTRequest.GetGenericArguments();
-
-        var concreteTResponse = concreteGenericTRequest.GetInterfaces()
-            .FirstOrDefault(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IRequest<>))
-            ?.GetGenericArguments()
-            .FirstOrDefault();
-
-        var typeDefinition = openRequestHandlerInterface.GetGenericTypeDefinition();
-
-        var serviceType = concreteTResponse != null ?
-            typeDefinition.MakeGenericType(concreteGenericTRequest, concreteTResponse) :
-            typeDefinition.MakeGenericType(concreteGenericTRequest);
-
-        return (serviceType, openRequestHandlerImplementation.MakeGenericType(closingTypes));
-    }
-
-    private static List<Type>? GetConcreteRequestTypes(Type openRequestHandlerInterface, Type openRequestHandlerImplementation, IEnumerable<Assembly> assembliesToScan, CancellationToken cancellationToken)
-    {
-        //request generic type constraints       
-        var constraintsForEachParameter = openRequestHandlerImplementation
-            .GetGenericArguments()
-            .Select(x => x.GetGenericParameterConstraints())
-            .ToList();
-
-        var typesThatCanCloseForEachParameter = constraintsForEachParameter
-            .Select(constraints => assembliesToScan
-                .SelectMany(assembly => assembly.GetTypes())
-                .Where(type => type.IsClass && !type.IsAbstract && constraints.All(constraint => constraint.IsAssignableFrom(type))).ToList()
-            ).ToList();
-
-        var requestType = openRequestHandlerInterface.GenericTypeArguments.First();
-
-        if (requestType.IsGenericParameter)
-            return null;
-
-        var requestGenericTypeDefinition = requestType.GetGenericTypeDefinition();
-              
-        var combinations = GenerateCombinations(requestType, typesThatCanCloseForEachParameter, 0, cancellationToken);
-
-        return combinations.Select(types => requestGenericTypeDefinition.MakeGenericType(types.ToArray())).ToList();
-    }
-
-    // Method to generate combinations recursively
-    public static List<List<Type>> GenerateCombinations(Type requestType, List<List<Type>> lists, int depth = 0, CancellationToken cancellationToken = default)
-    {
-        if (depth == 0)
-        {
-            // Initial checks
-            if (MaxGenericTypeParameters > 0 && lists.Count > MaxGenericTypeParameters)
-                throw new ArgumentException($"Error registering the generic type: {requestType.FullName}. The number of generic type parameters exceeds the maximum allowed ({MaxGenericTypeParameters}).");
-
-            foreach (var list in lists)
-            {
-                if (MaxTypesClosing > 0 && list.Count > MaxTypesClosing)
-                    throw new ArgumentException($"Error registering the generic type: {requestType.FullName}. One of the generic type parameter's count of types that can close exceeds the maximum length allowed ({MaxTypesClosing}).");
-            }
-
-            // Calculate the total number of combinations
-            long totalCombinations = 1;
-            foreach (var list in lists)
-            {
-                totalCombinations *= list.Count;
-                if (MaxGenericTypeParameters > 0 && totalCombinations > MaxGenericTypeRegistrations)
-                    throw new ArgumentException($"Error registering the generic type: {requestType.FullName}. The total number of generic type registrations exceeds the maximum allowed ({MaxGenericTypeRegistrations}).");
-            }
-        }
-
-        if (depth >= lists.Count)
-            return new List<List<Type>> { new List<Type>() };
-       
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var currentList = lists[depth];
-        var childCombinations = GenerateCombinations(requestType, lists, depth + 1, cancellationToken);
-        var combinations = new List<List<Type>>();
-
-        foreach (var item in currentList)
-        {
-            foreach (var childCombination in childCombinations)
-            {
-                var currentCombination = new List<Type> { item };
-                currentCombination.AddRange(childCombination);
-                combinations.Add(currentCombination);
-            }
-        }
-
-        return combinations;
-    }
-
-    private static void AddAllConcretionsThatClose(Type openRequestInterface, List<Type> concretions, IServiceCollection services, IEnumerable<Assembly> assembliesToScan, CancellationToken cancellationToken)
-    {
-        foreach (var concretion in concretions)
-        {   
-            var concreteRequests = GetConcreteRequestTypes(openRequestInterface, concretion, assembliesToScan, cancellationToken);
-
-            if (concreteRequests is null)
-                continue;
-
-            var registrationTypes = concreteRequests
-                .Select(concreteRequest => GetConcreteRegistrationTypes(openRequestInterface, concreteRequest, concretion));
-
-            foreach (var (Service, Implementation) in registrationTypes)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                services.AddTransient(Service, Implementation);
             }
         }
     }
@@ -378,12 +224,6 @@ public static class ServiceRegistrar
         return !type.IsAbstract && !type.IsInterface;
     }
 
-    private static void Fill<T>(this IList<T> list, T value)
-    {
-        if (list.Contains(value)) return;
-        list.Add(value);
-    }
-
     public static void AddRequiredServices(IServiceCollection services, MediatRServiceConfiguration serviceConfiguration)
     {
         // Use TryAdd, so any existing ServiceFactory/IMediator registration doesn't get overridden
@@ -446,6 +286,28 @@ public static class ServiceRegistrar
         if (hasAnyRegistrationsOfSubBehaviorType)
         {
             services.TryAddEnumerable(new ServiceDescriptor(typeof(IPipelineBehavior<,>), behaviorType, ServiceLifetime.Transient));
+        }
+    }
+
+    public static void AddDynamicServiceProvider(IServiceCollection services, MediatRServiceConfiguration configuration) 
+    {
+        var serviceDescriptor = services.FirstOrDefault(x => x.ServiceType == typeof(IMediator));
+        var mediatorTypeToUse = serviceDescriptor?.ImplementationType ?? configuration.MediatorImplementationType;
+        if (serviceDescriptor != null)
+        {
+            //services.Remove(serviceDescriptor);
+            services.AddTransient<IMediator>(sp =>
+            {
+                // Wrap the root provider with the dynamic registry
+                var rootProvider = sp.GetRequiredService<IServiceProvider>();
+                var dynamicRegistry = new DynamicServiceProvider(rootProvider);
+
+                dynamicRegistry.AddService(typeof(IMediator), _ =>
+                    Activator.CreateInstance(mediatorTypeToUse, dynamicRegistry, dynamicRegistry.GetService(typeof(INotificationPublisher)))!,
+                    ServiceLifetime.Transient);
+
+                return dynamicRegistry.GetService<IMediator>()!;
+            });
         }
     }
 }

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/AssemblyResolutionTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/AssemblyResolutionTests.cs
@@ -20,7 +20,7 @@ public class AssemblyResolutionTests
             cfg.RegisterServicesFromAssembly(typeof(Ping).Assembly);
             cfg.RegisterGenericHandlers = true;
         });
-        _provider = services.BuildServiceProvider();
+        _provider = services.BuildServiceProvider();        
     }
 
     [Fact]
@@ -64,26 +64,26 @@ public class AssemblyResolutionTests
     }
 
     [Fact]
-    public void ShouldResolveGenericVoidRequestHandler()
+    public void ShouldNotResolveGenericVoidRequestHandler()
     {
-        _provider.GetService<IRequestHandler<OpenGenericVoidRequest<ConcreteTypeArgument>>>().ShouldNotBeNull();
+        _provider.GetService<IRequestHandler<OpenGenericVoidRequest<ConcreteTypeArgument>>>().ShouldBeNull();
     }
 
     [Fact]
-    public void ShouldResolveGenericReturnTypeRequestHandler()
+    public void ShouldNotResolveGenericReturnTypeRequestHandler()
     {
-        _provider.GetService<IRequestHandler<OpenGenericReturnTypeRequest<ConcreteTypeArgument>, string>>().ShouldNotBeNull();
+        _provider.GetService<IRequestHandler<OpenGenericReturnTypeRequest<ConcreteTypeArgument>, string>>().ShouldBeNull();
     }
 
     [Fact]
-    public void ShouldResolveGenericPingRequestHandler()
+    public void ShouldNotResolveGenericPingRequestHandler()
     {
-        _provider.GetService<IRequestHandler<GenericPing<Pong>, Pong>>().ShouldNotBeNull();
+        _provider.GetService<IRequestHandler<GenericPing<Pong>, Pong>>().ShouldBeNull();
     }
 
     [Fact]
-    public void ShouldResolveVoidGenericPingRequestHandler()
+    public void ShouldNotResolveVoidGenericPingRequestHandler()
     {
-        _provider.GetService<IRequestHandler<VoidGenericPing<Pong>>>().ShouldNotBeNull();
+        _provider.GetService<IRequestHandler<VoidGenericPing<Pong>>>().ShouldBeNull();
     }
 }

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/DynamicServiceProviderTests.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/DynamicServiceProviderTests.cs
@@ -1,0 +1,49 @@
+﻿using MediatR.Registration;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using static MediatR.Tests.SendTests;
+
+namespace MediatR.Tests.MicrosoftExtensionsDI
+{
+    public class DynamicServiceProviderTests
+    {
+        private readonly DynamicServiceProvider _dynamicServiceProvider;
+
+        public DynamicServiceProviderTests()
+        {
+            var services = new ServiceCollection();
+            services.AddMediatR(cfg =>
+            {
+                cfg.RegisterServicesFromAssemblies(typeof(Pong).Assembly);
+                cfg.RegisterGenericHandlers = true;
+            });
+            services.AddSingleton(new Dependency());
+            var rootProvider = services.BuildServiceProvider();
+            _dynamicServiceProvider = new DynamicServiceProvider(rootProvider);
+        }
+
+        [Fact]
+        public void ShouldNotRescanForGenericHandlerAfterFirstRegistration()
+        {
+            var firstHandler = _dynamicServiceProvider.GetService<IRequestHandler<GenericPing<Pong>, Pong>>();
+            firstHandler.ShouldNotBeNull();
+
+            var secondHandler = _dynamicServiceProvider.GetService<IRequestHandler<GenericPing<Pong>, Pong>>();
+           
+            secondHandler!.GetType().ShouldBeSameAs(firstHandler.GetType());
+
+            var serviceDescriptorCount = _dynamicServiceProvider
+                .GetAllServiceDescriptors()
+                .Count(sd => sd.ServiceType == typeof(IRequestHandler<GenericPing<Pong>, Pong>));
+
+            serviceDescriptorCount.ShouldBe(1);
+        }
+    }
+}

--- a/test/MediatR.Tests/MicrosoftExtensionsDI/Handlers.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/Handlers.cs
@@ -177,6 +177,10 @@ namespace MediatR.Extensions.Microsoft.DependencyInjection.Tests
 
     class MyCustomMediator : IMediator
     {
+        public MyCustomMediator() { }
+        public MyCustomMediator(IServiceProvider provider) { }
+        public MyCustomMediator(IServiceProvider provider, INotificationPublisher publisher) { }
+       
         public Task<object?> Send(object request, CancellationToken cancellationToken = new())
         {
             throw new System.NotImplementedException();

--- a/test/MediatR.Tests/SendTests.cs
+++ b/test/MediatR.Tests/SendTests.cs
@@ -24,6 +24,7 @@ public class SendTests
             cfg.RegisterServicesFromAssemblies(typeof(Ping).Assembly);
             cfg.AddOpenBehavior(typeof(TimeoutBehavior<,>), ServiceLifetime.Transient);
             cfg.RegisterGenericHandlers = true;
+            
         });
         services.AddSingleton(_dependency);
         _serviceProvider = services.BuildServiceProvider();
@@ -360,7 +361,7 @@ public class SendTests
     {
         var request = new TimeoutRequest2();
         int result = 0;
-
+       
         var exception = await Should.ThrowAsync<TaskCanceledException>(async () => { result = await _mediator.Send(request); });
 
         exception.ShouldNotBeNull();


### PR DESCRIPTION
Ok @jbogard  I know how much you disliked the eager loading strategy of the first generic handler registration implementation so I took a shot at making a lazy loaded implementation that only scans the assembly when you request a generic handler service that is not already registered. This on demand approach seems to be exactly what you were describing to me. Please review. :)

## Summary
This PR introduces an optimized mechanism for registering generic handlers in `MediatR`. The current implementation scans all assemblies passed to `MediatR `during startup to find every possible concrete implementation and service type that satisfies all generic handler constraints. This PR modifies the behavior to scan and register generic handler services on-demand, triggered only when a specific service is requested.

This feature remains opt-in and can be enabled by setting the `RegisterGenericHandlers` configuration flag to true.

## Changes Made
#### Optimized Generic Handler Registration:
-  The registration process now scans assemblies only when a specific service is requested, rather than eagerly scanning all possible types during startup.
-  Once a service is resolved, the registration is cached for future requests.

#### Dynamic Service Provider Integration:
- Introduced dynamic resolution and caching for generic handlers, minimizing the startup overhead.

#### Backward Compatibility:
- The feature remains optional and is controlled via the `RegisterGenericHandlers` flag in the `MediatR` configuration.
- All previous tests are passing.

#### Code Refactor:
- Removed old `ServiceRegistrar` logic used for previous eager loading of generic handlers. 
- Removed old configuration properties that attempted to restrain the user from soft locking their app.
- Extracted and modularized some key logic for resolving generic handler types.
- Improved readability and maintainability by reducing logic.

## Pros
#### Improved Performance:
- Reduces startup time by avoiding eager scanning of all assemblies for generic handlers.
- Registration occurs only for the requested generic handler service, minimizing unnecessary work.

#### Lower Memory Overhead:
- Decreases the number of service descriptors stored in the `IServiceCollection `since only required services are registered.

#### Scalability:
- Particularly beneficial for applications with large assemblies and many potential generic handlers, as it avoids a full assembly scan.

#### Maintains Flexibility:
- Keeps the feature opt-in via `RegisterGenericHandlers`, ensuring no impact on existing applications unless explicitly enabled.

#### Compatibility:
- Fully backward-compatible with existing configurations and workflows.
- No third party dependencies required.

## Cons
#### Potential Runtime Costs:
- The first request for a generic handler incurs a slight delay due to on-demand scanning and registration.
- Subsequent requests are unaffected due to caching.

#### Increased Complexity:
- The dynamic registration mechanism adds complexity to the codebase, which may require additional documentation and onboarding for contributors.

## Conclusion
This PR significantly optimizes the generic handler registration process, making it more efficient and scalable while maintaining backward compatibility. By deferring the registration of generic handlers to runtime and caching them for subsequent use, it strikes a balance between performance and flexibility.

