### PR TITLE
fixed mini typo

### DIFF
--- a/src/MediatR/Mediator.cs
+++ b/src/MediatR/Mediator.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 using Wrappers;
 
 /// <summary>
-/// Default mediator implementation relying on single- and multi instance delegates for resolving handlers.
+/// Default mediator implementation relying on single and multi instance delegates for resolving handlers.
 /// </summary>
 public class Mediator : IMediator
 {


### PR DESCRIPTION
Fixes a minor typo in the XML comment of Mediator.cs